### PR TITLE
유저 정보 조회 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	testImplementation 'com.h2database:h2:2.1.214'
+	compileOnly('com.h2database:h2:2.1.214')
 }
 
 spotless {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -22,3 +22,7 @@ Audy API 명세서
 
 include::{snippets}/sample-controller-test/샘플_저장/auto-section.adoc[]
 include::{snippets}/sample-controller-test/샘플_전체_조회/auto-section.adoc[]
+
+== user API
+
+include::{snippets}/user-controller-test/유저_조회/auto-section.adoc[]

--- a/src/main/java/com/pcb/audy/domain/user/controller/UserController.java
+++ b/src/main/java/com/pcb/audy/domain/user/controller/UserController.java
@@ -1,0 +1,22 @@
+package com.pcb.audy.domain.user.controller;
+
+import com.pcb.audy.domain.user.dto.response.UserGetRes;
+import com.pcb.audy.domain.user.service.UserService;
+import com.pcb.audy.global.response.BasicResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping
+    public BasicResponse<UserGetRes> getUser(@RequestParam Long userId) {
+        return BasicResponse.success(userService.getUser(userId));
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/user/dto/response/UserGetRes.java
+++ b/src/main/java/com/pcb/audy/domain/user/dto/response/UserGetRes.java
@@ -1,0 +1,23 @@
+package com.pcb.audy.domain.user.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserGetRes {
+    private Long userId;
+    private String email;
+    private String username;
+    private String imageUrl;
+
+    @Builder
+    private UserGetRes(Long userId, String email, String username, String imageUrl) {
+        this.userId = userId;
+        this.email = email;
+        this.username = username;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/pcb/audy/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     User findByOauthId(String oauthId);
 
     User findByEmail(String email);
+
+    User findByUserId(Long userId);
 }

--- a/src/main/java/com/pcb/audy/domain/user/service/UserService.java
+++ b/src/main/java/com/pcb/audy/domain/user/service/UserService.java
@@ -1,0 +1,20 @@
+package com.pcb.audy.domain.user.service;
+
+import com.pcb.audy.domain.user.dto.response.UserGetRes;
+import com.pcb.audy.domain.user.entity.User;
+import com.pcb.audy.domain.user.repository.UserRepository;
+import com.pcb.audy.global.validator.UserValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserGetRes getUser(Long userId) {
+        User user = userRepository.findByUserId(userId);
+        UserValidator.validate(user);
+        return UserServiceMapper.INSTANCE.toUserGetRes(user);
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/user/service/UserServiceMapper.java
+++ b/src/main/java/com/pcb/audy/domain/user/service/UserServiceMapper.java
@@ -1,0 +1,13 @@
+package com.pcb.audy.domain.user.service;
+
+import com.pcb.audy.domain.user.dto.response.UserGetRes;
+import com.pcb.audy.domain.user.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface UserServiceMapper {
+    UserServiceMapper INSTANCE = Mappers.getMapper(UserServiceMapper.class);
+
+    UserGetRes toUserGetRes(User user);
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;
+    username: sa
+    password:
+
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+      dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+    defer-datasource-initialization: true
+    sql:
+      init:
+        mode: always
+        encoding: UTF-8

--- a/src/test/java/com/pcb/audy/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,39 @@
+package com.pcb.audy.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.pcb.audy.domain.BaseMvcTest;
+import com.pcb.audy.domain.user.dto.response.UserGetRes;
+import com.pcb.audy.domain.user.service.UserService;
+import com.pcb.audy.test.UserTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(controllers = {UserController.class})
+class UserControllerTest extends BaseMvcTest implements UserTest {
+    @MockBean private UserService userService;
+
+    @Test
+    @DisplayName("유저 조회 테스트")
+    void 유저_조회() throws Exception {
+        Long userId = TEST_USER_ID;
+        UserGetRes userGetRes =
+                UserGetRes.builder()
+                        .userId(TEST_USER_ID)
+                        .email(TEST_USER_EMAIL)
+                        .username(TEST_USER_NAME)
+                        .imageUrl(TEST_USER_IMAGE_URL)
+                        .build();
+        when(userService.getUser(any())).thenReturn(userGetRes);
+        this.mockMvc
+                .perform(get("/v1/users").param("userId", String.valueOf(userId)))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/pcb/audy/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,32 @@
+package com.pcb.audy.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.pcb.audy.domain.user.entity.User;
+import com.pcb.audy.test.UserTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryTest implements UserTest {
+    @Autowired private UserRepository userRepository;
+
+    @Test
+    @DisplayName("oauthId로 유저 조회 테스트")
+    void oauthId_유저_조회() {
+        // given
+        User savedUser = userRepository.save(TEST_USER);
+
+        // when
+        User user = userRepository.findByOauthId(TEST_OAUTH_ID);
+
+        // then
+        assertThat(user).isEqualTo(savedUser);
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/pcb/audy/domain/user/repository/UserRepositoryTest.java
@@ -42,4 +42,17 @@ class UserRepositoryTest implements UserTest {
         // then
         assertThat(user).isEqualTo(savedUser);
     }
+
+    @Test
+    @DisplayName("userId로 유저 조회 테스트")
+    void userId_유저_조회() {
+        // given
+        User savedUser = userRepository.save(TEST_USER);
+
+        // when
+        User user = userRepository.findByUserId(savedUser.getUserId());
+
+        // then
+        assertThat(user).isEqualTo(savedUser);
+    }
 }

--- a/src/test/java/com/pcb/audy/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/pcb/audy/domain/user/repository/UserRepositoryTest.java
@@ -29,4 +29,17 @@ class UserRepositoryTest implements UserTest {
         // then
         assertThat(user).isEqualTo(savedUser);
     }
+
+    @Test
+    @DisplayName("email로 유저 조회 테스트")
+    void email_유저_조회() {
+        // given
+        User savedUser = userRepository.save(TEST_USER);
+
+        // when
+        User user = userRepository.findByEmail(TEST_USER_EMAIL);
+
+        // then
+        assertThat(user).isEqualTo(savedUser);
+    }
 }

--- a/src/test/java/com/pcb/audy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/user/service/UserServiceTest.java
@@ -35,6 +35,6 @@ class UserServiceTest implements UserTest {
         verify(userRepository).findByUserId(any());
         assertThat(userGetRes.getEmail()).isEqualTo(TEST_USER_EMAIL);
         assertThat(userGetRes.getUsername()).isEqualTo(TEST_USER_NAME);
-        assertThat(userGetRes.getImageUrl()).isEqualTo(TEST_USER_PROFILE_URL);
+        assertThat(userGetRes.getImageUrl()).isEqualTo(TEST_USER_IMAGE_URL);
     }
 }

--- a/src/test/java/com/pcb/audy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/user/service/UserServiceTest.java
@@ -1,0 +1,40 @@
+package com.pcb.audy.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pcb.audy.domain.user.dto.response.UserGetRes;
+import com.pcb.audy.domain.user.repository.UserRepository;
+import com.pcb.audy.test.UserTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest implements UserTest {
+    @InjectMocks private UserService userService;
+
+    @Mock private UserRepository userRepository;
+
+    @Test
+    @DisplayName("유저 조회 테스트")
+    void 유저_조회() {
+        // given
+        Long userId = TEST_USER_ID;
+        when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
+
+        // when
+        UserGetRes userGetRes = userService.getUser(userId);
+
+        // then
+        verify(userRepository).findByUserId(any());
+        assertThat(userGetRes.getEmail()).isEqualTo(TEST_USER_EMAIL);
+        assertThat(userGetRes.getUsername()).isEqualTo(TEST_USER_NAME);
+        assertThat(userGetRes.getImageUrl()).isEqualTo(TEST_USER_PROFILE_URL);
+    }
+}

--- a/src/test/java/com/pcb/audy/test/UserTest.java
+++ b/src/test/java/com/pcb/audy/test/UserTest.java
@@ -11,7 +11,7 @@ public interface UserTest {
     String TEST_OAUTH_ID = "oauthId";
     String TEST_USER_NAME = "username";
     String TEST_USER_EMAIL = "username@gmail.com";
-    String TEST_USER_PROFILE_URL = "imageUrl";
+    String TEST_USER_IMAGE_URL = "imageUrl";
 
     User TEST_USER =
             User.builder()
@@ -21,6 +21,6 @@ public interface UserTest {
                     .username(TEST_USER_NAME)
                     .authority(USER)
                     .social(KAKAO)
-                    .imageUrl(TEST_USER_PROFILE_URL)
+                    .imageUrl(TEST_USER_IMAGE_URL)
                     .build();
 }

--- a/src/test/java/com/pcb/audy/test/UserTest.java
+++ b/src/test/java/com/pcb/audy/test/UserTest.java
@@ -1,0 +1,26 @@
+package com.pcb.audy.test;
+
+import static com.pcb.audy.global.meta.Authority.USER;
+import static com.pcb.audy.global.meta.Social.KAKAO;
+
+import com.pcb.audy.domain.user.entity.User;
+
+public interface UserTest {
+
+    Long TEST_USER_ID = 1L;
+    String TEST_OAUTH_ID = "oauthId";
+    String TEST_USER_NAME = "username";
+    String TEST_USER_EMAIL = "username@gmail.com";
+    String TEST_USER_PROFILE_URL = "imageUrl";
+
+    User TEST_USER =
+            User.builder()
+                    .userId(TEST_USER_ID)
+                    .oauthId(TEST_OAUTH_ID)
+                    .email(TEST_USER_EMAIL)
+                    .username(TEST_USER_NAME)
+                    .authority(USER)
+                    .social(KAKAO)
+                    .imageUrl(TEST_USER_PROFILE_URL)
+                    .build();
+}


### PR DESCRIPTION
## 개요
유저 정보 조회 api를 추가합니다.

## 작업사항
- 유저 정보 조회 api 추가
-  테스트코드 추가
- restdocs에 api 추가

## 관련 이슈
- close #18 
