### PR TITLE
핀 저장 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -26,3 +26,7 @@ include::{snippets}/sample-controller-test/샘플_전체_조회/auto-section.ado
 == user API
 
 include::{snippets}/user-controller-test/유저_조회/auto-section.adoc[]
+
+== pin API
+
+include::{snippets}/pin-controller-test/pin_저장/auto-section.adoc[]

--- a/src/main/java/com/pcb/audy/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/pcb/audy/domain/course/repository/CourseRepository.java
@@ -1,0 +1,8 @@
+package com.pcb.audy.domain.course.repository;
+
+import com.pcb.audy.domain.course.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+    Course findByCourseId(Long courseId);
+}

--- a/src/main/java/com/pcb/audy/domain/pin/controller/PinController.java
+++ b/src/main/java/com/pcb/audy/domain/pin/controller/PinController.java
@@ -1,0 +1,23 @@
+package com.pcb.audy.domain.pin.controller;
+
+import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
+import com.pcb.audy.domain.pin.service.PinService;
+import com.pcb.audy.global.response.BasicResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/pins")
+@RequiredArgsConstructor
+public class PinController {
+    private final PinService pinService;
+
+    @PostMapping
+    public BasicResponse<PinSaveRes> savePin(@RequestBody PinSaveReq pinSaveReq) {
+        return BasicResponse.success(pinService.savePin(pinSaveReq));
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/pin/dto/request/PinSaveReq.java
+++ b/src/main/java/com/pcb/audy/domain/pin/dto/request/PinSaveReq.java
@@ -1,0 +1,36 @@
+package com.pcb.audy.domain.pin.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PinSaveReq {
+    private Long courseId;
+    private String pinName;
+    private String originName;
+    private Double latitude;
+    private Double longitude;
+    private String address;
+    private Integer sequence;
+
+    @Builder
+    private PinSaveReq(
+            Long courseId,
+            String pinName,
+            String originName,
+            Double latitude,
+            Double longitude,
+            String address,
+            Integer sequence) {
+        this.courseId = courseId;
+        this.pinName = pinName;
+        this.originName = originName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.address = address;
+        this.sequence = sequence;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/pin/dto/response/PinSaveRes.java
+++ b/src/main/java/com/pcb/audy/domain/pin/dto/response/PinSaveRes.java
@@ -1,0 +1,6 @@
+package com.pcb.audy.domain.pin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class PinSaveRes {}

--- a/src/main/java/com/pcb/audy/domain/pin/entity/Pin.java
+++ b/src/main/java/com/pcb/audy/domain/pin/entity/Pin.java
@@ -5,12 +5,11 @@ import com.pcb.audy.domain.model.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,9 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tb_pin")
 public class Pin extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long pinId;
+    @Id private UUID pinId;
 
     private String pinName;
     private String originName;
@@ -38,7 +35,7 @@ public class Pin extends BaseEntity {
 
     @Builder
     private Pin(
-            Long pinId,
+            UUID pinId,
             String pinName,
             String originName,
             Double latitude,

--- a/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
+++ b/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
@@ -1,0 +1,52 @@
+package com.pcb.audy.domain.pin.service;
+
+import com.pcb.audy.domain.course.entity.Course;
+import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
+import com.pcb.audy.domain.pin.entity.Pin;
+import com.pcb.audy.global.redis.RedisProvider;
+import com.pcb.audy.global.validator.CourseValidator;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PinService {
+    private final RedisProvider redisProvider;
+    private final CourseRepository courseRepository;
+    private final String SEPARATOR = ":";
+
+    // TODO fix TTL
+    private final long PIN_EXPIRE_TIME = Integer.MAX_VALUE;
+
+    public PinSaveRes savePin(PinSaveReq pinSaveReq) {
+        UUID pinId = getPinId();
+        redisProvider.set(
+                pinSaveReq.getCourseId() + SEPARATOR + pinId,
+                Pin.builder()
+                        .pinId(pinId)
+                        .pinName(pinSaveReq.getPinName())
+                        .originName(pinSaveReq.getOriginName())
+                        .latitude(pinSaveReq.getLatitude())
+                        .longitude(pinSaveReq.getLongitude())
+                        .address(pinSaveReq.getAddress())
+                        .sequence(pinSaveReq.getSequence())
+                        .course(getCourse(pinSaveReq.getCourseId()))
+                        .build(),
+                PIN_EXPIRE_TIME);
+
+        return new PinSaveRes();
+    }
+
+    private Course getCourse(Long courseId) {
+        Course course = courseRepository.findByCourseId(courseId);
+        CourseValidator.validate(course);
+        return course;
+    }
+
+    private UUID getPinId() {
+        return UUID.randomUUID();
+    }
+}

--- a/src/main/java/com/pcb/audy/global/response/ResultCode.java
+++ b/src/main/java/com/pcb/audy/global/response/ResultCode.java
@@ -14,7 +14,9 @@ public enum ResultCode {
     UNKNOWN_SOCIAL(1001, "알 수 없는 소셜입니다."),
     INVALID_TOKEN(1002, "유효하지 않은 토큰입니다."),
 
-    NOT_FOUND_USER(2000, "유저를 찾을 수 없습니다.");
+    NOT_FOUND_USER(2000, "유저를 찾을 수 없습니다."),
+
+    NOT_FOUND_COURSE(3000, "코스를 찾을 수 없습니다.");
 
     private Integer code;
     private String message;

--- a/src/main/java/com/pcb/audy/global/validator/CourseValidator.java
+++ b/src/main/java/com/pcb/audy/global/validator/CourseValidator.java
@@ -1,0 +1,18 @@
+package com.pcb.audy.global.validator;
+
+import static com.pcb.audy.global.response.ResultCode.NOT_FOUND_COURSE;
+
+import com.pcb.audy.domain.course.entity.Course;
+import com.pcb.audy.global.exception.GlobalException;
+
+public class CourseValidator {
+    public static void validate(Course course) {
+        if (!isExistCourse(course)) {
+            throw new GlobalException(NOT_FOUND_COURSE);
+        }
+    }
+
+    private static boolean isExistCourse(Course course) {
+        return course != null;
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/course/repository/CourseRepositoryTest.java
+++ b/src/test/java/com/pcb/audy/domain/course/repository/CourseRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.pcb.audy.domain.course.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.pcb.audy.domain.course.entity.Course;
+import com.pcb.audy.test.CourseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CourseRepositoryTest implements CourseTest {
+    @Autowired private CourseRepository courseRepository;
+
+    @Test
+    @DisplayName("courseId로 코스 조회 테스트")
+    void courseId_코스_조회() {
+        // given
+        Course savedCourse = courseRepository.save(TEST_COURSE);
+
+        // when
+        Course course = courseRepository.findByCourseId(savedCourse.getCourseId());
+
+        // then
+        assertThat(course.getCourseId()).isEqualTo(savedCourse.getCourseId());
+        assertThat(course.getCourseName()).isEqualTo(savedCourse.getCourseName());
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/pin/controller/PinControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/pin/controller/PinControllerTest.java
@@ -1,0 +1,47 @@
+package com.pcb.audy.domain.pin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.pcb.audy.domain.BaseMvcTest;
+import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
+import com.pcb.audy.domain.pin.service.PinService;
+import com.pcb.audy.test.PinTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(controllers = {PinController.class})
+class PinControllerTest extends BaseMvcTest implements PinTest {
+    @MockBean private PinService pinService;
+
+    @Test
+    @DisplayName("pin 저장 테스트")
+    void pin_저장() throws Exception {
+        PinSaveReq pinSaveReq =
+                PinSaveReq.builder()
+                        .courseId(TEST_COURSE_ID)
+                        .pinName(TEST_PIN_NAME)
+                        .originName(TEST_ORIGIN_NAME)
+                        .latitude(TEST_LATITUDE)
+                        .longitude(TEST_LONGITUDE)
+                        .address(TEST_ADDRESS)
+                        .sequence(TEST_SEQUENCE)
+                        .build();
+        PinSaveRes pinSaveRes = new PinSaveRes();
+        when(pinService.savePin(any())).thenReturn(pinSaveRes);
+        this.mockMvc
+                .perform(
+                        post("/v1/pins")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(pinSaveReq)))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/pin/service/PinServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/pin/service/PinServiceTest.java
@@ -1,0 +1,49 @@
+package com.pcb.audy.domain.pin.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.global.redis.RedisProvider;
+import com.pcb.audy.test.PinTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PinServiceTest implements PinTest {
+    @InjectMocks private PinService pinService;
+
+    @Mock private RedisProvider redisProvider;
+    @Mock private CourseRepository courseRepository;
+
+    @Test
+    @DisplayName("pin 저장 테스트")
+    void pin_저장() {
+        // given
+        PinSaveReq pinSaveReq =
+                PinSaveReq.builder()
+                        .courseId(TEST_COURSE_ID)
+                        .pinName(TEST_PIN_NAME)
+                        .originName(TEST_ORIGIN_NAME)
+                        .latitude(TEST_LATITUDE)
+                        .longitude(TEST_LONGITUDE)
+                        .address(TEST_ADDRESS)
+                        .sequence(TEST_SEQUENCE)
+                        .build();
+        when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
+
+        // when
+        pinService.savePin(pinSaveReq);
+
+        // then
+        verify(courseRepository).findByCourseId(any());
+        verify(redisProvider).set(any(), any(), anyLong());
+    }
+}

--- a/src/test/java/com/pcb/audy/test/CourseTest.java
+++ b/src/test/java/com/pcb/audy/test/CourseTest.java
@@ -1,0 +1,12 @@
+package com.pcb.audy.test;
+
+import com.pcb.audy.domain.course.entity.Course;
+
+public interface CourseTest {
+
+    Long TEST_COURSE_ID = 1L;
+    String TEST_COURSE_NAME = "course";
+
+    Course TEST_COURSE =
+            Course.builder().courseId(TEST_COURSE_ID).courseName(TEST_COURSE_NAME).build();
+}

--- a/src/test/java/com/pcb/audy/test/PinTest.java
+++ b/src/test/java/com/pcb/audy/test/PinTest.java
@@ -1,0 +1,26 @@
+package com.pcb.audy.test;
+
+import com.pcb.audy.domain.pin.entity.Pin;
+import java.util.UUID;
+
+public interface PinTest extends CourseTest {
+    UUID TEST_PIN_ID = UUID.randomUUID();
+    String TEST_PIN_NAME = "pinName";
+    String TEST_ORIGIN_NAME = "originName";
+    Double TEST_LATITUDE = 1.0;
+    Double TEST_LONGITUDE = 1.0;
+    String TEST_ADDRESS = "address";
+    Integer TEST_SEQUENCE = 1;
+
+    Pin TEST_PIN =
+            Pin.builder()
+                    .pinId(TEST_PIN_ID)
+                    .pinName(TEST_PIN_NAME)
+                    .originName(TEST_ORIGIN_NAME)
+                    .latitude(TEST_LATITUDE)
+                    .longitude(TEST_LONGITUDE)
+                    .address(TEST_ADDRESS)
+                    .sequence(TEST_SEQUENCE)
+                    .course(TEST_COURSE)
+                    .build();
+}


### PR DESCRIPTION
## 개요
핀 저장 api를 추가합니다.

## 작업사항
- 핀 저장 api 추가
- 테스트코드 추가
- restdocs에 api 추가

## 관련 이슈
- close #23 
