### PR TITLE
redis provider 테스트코드 추가

### DIFF
--- a/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
+++ b/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
@@ -68,4 +68,18 @@ class RedisProviderTest implements RedisTest {
         // then
         verify(redisTemplate).delete(anyString());
     }
+
+    @Test
+    @DisplayName("데이터 존재 확인 테스트")
+    void 데이터_존재_확인() {
+        // given
+        when(redisTemplate.hasKey(any())).thenReturn(TRUE);
+
+        // when
+        Boolean result = redisProvider.hasKey(TEST_KEY);
+
+        // then
+        verify(redisTemplate).hasKey(any());
+        assertThat(result).isEqualTo(TRUE);
+    }
 }

--- a/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
+++ b/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
@@ -1,6 +1,7 @@
 package com.pcb.audy.global.redis;
 
 import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -38,5 +39,21 @@ class RedisProviderTest implements RedisTest {
         verify(redisTemplate).delete(anyString());
         verify(redisTemplate).opsForValue();
         verify(valueOperations).set(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("데이터 조회 테스트")
+    void 데이터_조회() {
+        // given
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(any())).thenReturn(TEST_VALUE);
+
+        // when
+        String value = (String) redisProvider.get(TEST_KEY);
+
+        // then
+        verify(redisTemplate).opsForValue();
+        verify(valueOperations).get(any());
+        assertThat(value).isEqualTo(TEST_VALUE);
     }
 }

--- a/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
+++ b/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
@@ -56,4 +56,16 @@ class RedisProviderTest implements RedisTest {
         verify(valueOperations).get(any());
         assertThat(value).isEqualTo(TEST_VALUE);
     }
+
+    @Test
+    @DisplayName("데이터 삭제 테스트")
+    void 데이터_삭제() {
+        // given
+
+        // when
+        redisProvider.delete(TEST_KEY);
+
+        // then
+        verify(redisTemplate).delete(anyString());
+    }
 }

--- a/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
+++ b/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
@@ -1,0 +1,42 @@
+package com.pcb.audy.global.redis;
+
+import static java.lang.Boolean.TRUE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pcb.audy.test.RedisTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisProviderTest implements RedisTest {
+    @InjectMocks private RedisProvider redisProvider;
+
+    @Mock private RedisTemplate<String, Object> redisTemplate;
+    @Mock private ValueOperations<String, Object> valueOperations;
+
+    @Test
+    @DisplayName("데이터 저장 테스트")
+    void 데이터_저장() {
+        // given
+        when(redisTemplate.hasKey(any())).thenReturn(TRUE);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // when
+        redisProvider.set(TEST_KEY, TEST_VALUE, TEST_EXPIRE_TIME);
+
+        // then
+        verify(redisTemplate).hasKey(any());
+        verify(redisTemplate).delete(anyString());
+        verify(redisTemplate).opsForValue();
+        verify(valueOperations).set(any(), any(), any());
+    }
+}


### PR DESCRIPTION
## 개요
RedisProvider 테스트코드를 추가합니다.

## 작업사항
- 데이터 저장 테스트코드 추가
- 데이터 조회 테스트코드 추가
- 데이터 키 존재여부 확인 테스트코드 추가
- 데이터 삭제 테스트코드 추가

## 관련 이슈
- close #25 
