### PR TITLE
pin 이름 수정 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -30,3 +30,4 @@ include::{snippets}/user-controller-test/유저_조회/auto-section.adoc[]
 == pin API
 
 include::{snippets}/pin-controller-test/pin_저장/auto-section.adoc[]
+include::{snippets}/pin-controller-test/pin_이름_수정/auto-section.adoc[]

--- a/src/main/java/com/pcb/audy/domain/pin/controller/PinController.java
+++ b/src/main/java/com/pcb/audy/domain/pin/controller/PinController.java
@@ -1,10 +1,13 @@
 package com.pcb.audy.domain.pin.controller;
 
+import com.pcb.audy.domain.pin.dto.request.PinNameUpdateReq;
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinNameUpdateRes;
 import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
 import com.pcb.audy.domain.pin.service.PinService;
 import com.pcb.audy.global.response.BasicResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,5 +22,11 @@ public class PinController {
     @PostMapping
     public BasicResponse<PinSaveRes> savePin(@RequestBody PinSaveReq pinSaveReq) {
         return BasicResponse.success(pinService.savePin(pinSaveReq));
+    }
+
+    @PatchMapping
+    public BasicResponse<PinNameUpdateRes> updatePinName(
+            @RequestBody PinNameUpdateReq pinNameUpdateReq) {
+        return BasicResponse.success(pinService.updatePinName(pinNameUpdateReq));
     }
 }

--- a/src/main/java/com/pcb/audy/domain/pin/dto/request/PinNameUpdateReq.java
+++ b/src/main/java/com/pcb/audy/domain/pin/dto/request/PinNameUpdateReq.java
@@ -1,0 +1,22 @@
+package com.pcb.audy.domain.pin.dto.request;
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PinNameUpdateReq {
+    private Long courseId;
+    private UUID pinId;
+    private String pinName;
+
+    @Builder
+    private PinNameUpdateReq(Long courseId, UUID pinId, String pinName) {
+        this.courseId = courseId;
+        this.pinId = pinId;
+        this.pinName = pinName;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/pin/dto/response/PinNameUpdateRes.java
+++ b/src/main/java/com/pcb/audy/domain/pin/dto/response/PinNameUpdateRes.java
@@ -1,0 +1,6 @@
+package com.pcb.audy.domain.pin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class PinNameUpdateRes {}

--- a/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
+++ b/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
@@ -2,11 +2,14 @@ package com.pcb.audy.domain.pin.service;
 
 import com.pcb.audy.domain.course.entity.Course;
 import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.pin.dto.request.PinNameUpdateReq;
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinNameUpdateRes;
 import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
 import com.pcb.audy.domain.pin.entity.Pin;
 import com.pcb.audy.global.redis.RedisProvider;
 import com.pcb.audy.global.validator.CourseValidator;
+import com.pcb.audy.global.validator.PinValidator;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +27,7 @@ public class PinService {
     public PinSaveRes savePin(PinSaveReq pinSaveReq) {
         UUID pinId = getPinId();
         redisProvider.set(
-                pinSaveReq.getCourseId() + SEPARATOR + pinId,
+                getKey(pinSaveReq.getCourseId(), pinId),
                 Pin.builder()
                         .pinId(pinId)
                         .pinName(pinSaveReq.getPinName())
@@ -38,6 +41,31 @@ public class PinService {
                 PIN_EXPIRE_TIME);
 
         return new PinSaveRes();
+    }
+
+    public PinNameUpdateRes updatePinName(PinNameUpdateReq pinNameUpdateReq) {
+        String key = getKey(pinNameUpdateReq.getCourseId(), pinNameUpdateReq.getPinId());
+        Pin prevPin = (Pin) redisProvider.get(key);
+        PinValidator.validate(prevPin);
+        redisProvider.set(
+                key,
+                Pin.builder()
+                        .pinId(pinNameUpdateReq.getPinId())
+                        .pinName(pinNameUpdateReq.getPinName())
+                        .originName(prevPin.getOriginName())
+                        .latitude(prevPin.getLatitude())
+                        .longitude(prevPin.getLongitude())
+                        .address(prevPin.getAddress())
+                        .sequence(prevPin.getSequence())
+                        .course(prevPin.getCourse())
+                        .build(),
+                PIN_EXPIRE_TIME);
+
+        return new PinNameUpdateRes();
+    }
+
+    private String getKey(Long courseId, UUID pinId) {
+        return courseId + SEPARATOR + pinId;
     }
 
     private Course getCourse(Long courseId) {

--- a/src/main/java/com/pcb/audy/global/response/ResultCode.java
+++ b/src/main/java/com/pcb/audy/global/response/ResultCode.java
@@ -16,7 +16,9 @@ public enum ResultCode {
 
     NOT_FOUND_USER(2000, "유저를 찾을 수 없습니다."),
 
-    NOT_FOUND_COURSE(3000, "코스를 찾을 수 없습니다.");
+    NOT_FOUND_COURSE(3000, "코스를 찾을 수 없습니다."),
+
+    NOT_FOUND_PIN(4000, "핀을 찾을 수 없습니다.");
 
     private Integer code;
     private String message;

--- a/src/main/java/com/pcb/audy/global/validator/PinValidator.java
+++ b/src/main/java/com/pcb/audy/global/validator/PinValidator.java
@@ -1,0 +1,18 @@
+package com.pcb.audy.global.validator;
+
+import static com.pcb.audy.global.response.ResultCode.NOT_FOUND_PIN;
+
+import com.pcb.audy.domain.pin.entity.Pin;
+import com.pcb.audy.global.exception.GlobalException;
+
+public class PinValidator {
+    public static void validate(Pin pin) {
+        if (!isExistPin(pin)) {
+            throw new GlobalException(NOT_FOUND_PIN);
+        }
+    }
+
+    private static boolean isExistPin(Pin pin) {
+        return pin != null;
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/pin/controller/PinControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/pin/controller/PinControllerTest.java
@@ -2,12 +2,15 @@ package com.pcb.audy.domain.pin.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.pcb.audy.domain.BaseMvcTest;
+import com.pcb.audy.domain.pin.dto.request.PinNameUpdateReq;
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinNameUpdateRes;
 import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
 import com.pcb.audy.domain.pin.service.PinService;
 import com.pcb.audy.test.PinTest;
@@ -41,6 +44,26 @@ class PinControllerTest extends BaseMvcTest implements PinTest {
                         post("/v1/pins")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(pinSaveReq)))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("pin 이름 수정 테스트")
+    void pin_이름_수정() throws Exception {
+        PinNameUpdateReq pinNameUpdateReq =
+                PinNameUpdateReq.builder()
+                        .courseId(TEST_COURSE_ID)
+                        .pinId(TEST_PIN_ID)
+                        .pinName(TEST_UPDATED_PIN_NAME)
+                        .build();
+        PinNameUpdateRes pinNameUpdateRes = new PinNameUpdateRes();
+        when(pinService.updatePinName(any())).thenReturn(pinNameUpdateRes);
+        this.mockMvc
+                .perform(
+                        patch("/v1/pins")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(pinNameUpdateReq)))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/pcb/audy/domain/pin/service/PinServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/pin/service/PinServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.pin.dto.request.PinNameUpdateReq;
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
 import com.pcb.audy.global.redis.RedisProvider;
 import com.pcb.audy.test.PinTest;
@@ -44,6 +45,26 @@ class PinServiceTest implements PinTest {
 
         // then
         verify(courseRepository).findByCourseId(any());
+        verify(redisProvider).set(any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("pin 이름 수정 테스트")
+    void pin_이름_수정() {
+        // given
+        PinNameUpdateReq pinNameUpdateReq =
+                PinNameUpdateReq.builder()
+                        .courseId(TEST_COURSE_ID)
+                        .pinId(TEST_PIN_ID)
+                        .pinName(TEST_UPDATED_PIN_NAME)
+                        .build();
+        when(redisProvider.get(any())).thenReturn(TEST_PIN);
+
+        // when
+        pinService.updatePinName(pinNameUpdateReq);
+
+        // then
+        verify(redisProvider).get(any());
         verify(redisProvider).set(any(), any(), anyLong());
     }
 }

--- a/src/test/java/com/pcb/audy/test/PinTest.java
+++ b/src/test/java/com/pcb/audy/test/PinTest.java
@@ -12,6 +12,8 @@ public interface PinTest extends CourseTest {
     String TEST_ADDRESS = "address";
     Integer TEST_SEQUENCE = 1;
 
+    String TEST_UPDATED_PIN_NAME = "updatedPinName";
+
     Pin TEST_PIN =
             Pin.builder()
                     .pinId(TEST_PIN_ID)


### PR DESCRIPTION
## 개요
pin 이름 수정 api를 추가합니다.

## 작업사항
- pin 이름 수정 api 추가
- 테스트코드 추가
- restdocs에 api 추가

## 관련 이슈
- close #27 
