### PR TITLE
pin 삭제 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -31,6 +31,7 @@ include::{snippets}/user-controller-test/유저_조회/auto-section.adoc[]
 
 include::{snippets}/pin-controller-test/pin_저장/auto-section.adoc[]
 include::{snippets}/pin-controller-test/pin_이름_수정/auto-section.adoc[]
+include::{snippets}/pin-controller-test/pin_삭제/auto-section.adoc[]
 
 == course API
 

--- a/src/main/java/com/pcb/audy/domain/pin/controller/PinController.java
+++ b/src/main/java/com/pcb/audy/domain/pin/controller/PinController.java
@@ -1,12 +1,15 @@
 package com.pcb.audy.domain.pin.controller;
 
+import com.pcb.audy.domain.pin.dto.request.PinDeleteReq;
 import com.pcb.audy.domain.pin.dto.request.PinNameUpdateReq;
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinDeleteRes;
 import com.pcb.audy.domain.pin.dto.response.PinNameUpdateRes;
 import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
 import com.pcb.audy.domain.pin.service.PinService;
 import com.pcb.audy.global.response.BasicResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,5 +31,10 @@ public class PinController {
     public BasicResponse<PinNameUpdateRes> updatePinName(
             @RequestBody PinNameUpdateReq pinNameUpdateReq) {
         return BasicResponse.success(pinService.updatePinName(pinNameUpdateReq));
+    }
+
+    @DeleteMapping
+    public BasicResponse<PinDeleteRes> deletePin(@RequestBody PinDeleteReq pinDeleteReq) {
+        return BasicResponse.success(pinService.deletePin(pinDeleteReq));
     }
 }

--- a/src/main/java/com/pcb/audy/domain/pin/dto/request/PinDeleteReq.java
+++ b/src/main/java/com/pcb/audy/domain/pin/dto/request/PinDeleteReq.java
@@ -1,0 +1,20 @@
+package com.pcb.audy.domain.pin.dto.request;
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PinDeleteReq {
+    private Long courseId;
+    private UUID pinId;
+
+    @Builder
+    private PinDeleteReq(Long courseId, UUID pinId) {
+        this.courseId = courseId;
+        this.pinId = pinId;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/pin/dto/response/PinDeleteRes.java
+++ b/src/main/java/com/pcb/audy/domain/pin/dto/response/PinDeleteRes.java
@@ -1,0 +1,6 @@
+package com.pcb.audy.domain.pin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class PinDeleteRes {}

--- a/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
+++ b/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
@@ -2,8 +2,10 @@ package com.pcb.audy.domain.pin.service;
 
 import com.pcb.audy.domain.course.entity.Course;
 import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.pin.dto.request.PinDeleteReq;
 import com.pcb.audy.domain.pin.dto.request.PinNameUpdateReq;
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinDeleteRes;
 import com.pcb.audy.domain.pin.dto.response.PinNameUpdateRes;
 import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
 import com.pcb.audy.domain.pin.entity.Pin;
@@ -60,6 +62,14 @@ public class PinService {
                 PIN_EXPIRE_TIME);
 
         return new PinNameUpdateRes();
+    }
+
+    public PinDeleteRes deletePin(PinDeleteReq pinDeleteReq) {
+        String key = getKey(pinDeleteReq.getCourseId(), pinDeleteReq.getPinId());
+        Pin pin = (Pin) redisProvider.get(key);
+        PinValidator.validate(pin);
+        redisProvider.delete(key);
+        return new PinDeleteRes();
     }
 
     private String getKey(Long courseId, UUID pinId) {

--- a/src/test/java/com/pcb/audy/domain/pin/controller/PinControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/pin/controller/PinControllerTest.java
@@ -2,14 +2,17 @@ package com.pcb.audy.domain.pin.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.pcb.audy.domain.BaseMvcTest;
+import com.pcb.audy.domain.pin.dto.request.PinDeleteReq;
 import com.pcb.audy.domain.pin.dto.request.PinNameUpdateReq;
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinDeleteRes;
 import com.pcb.audy.domain.pin.dto.response.PinNameUpdateRes;
 import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
 import com.pcb.audy.domain.pin.service.PinService;
@@ -43,7 +46,8 @@ class PinControllerTest extends BaseMvcTest implements PinTest {
                 .perform(
                         post("/v1/pins")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(pinSaveReq)))
+                                .content(objectMapper.writeValueAsString(pinSaveReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -63,7 +67,25 @@ class PinControllerTest extends BaseMvcTest implements PinTest {
                 .perform(
                         patch("/v1/pins")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(pinNameUpdateReq)))
+                                .content(objectMapper.writeValueAsString(pinNameUpdateReq))
+                                .principal(this.mockPrincipal))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("pin 삭제 테스트")
+    void pin_삭제() throws Exception {
+        PinDeleteReq pinDeleteReq =
+                PinDeleteReq.builder().courseId(TEST_COURSE_ID).pinId(TEST_PIN_ID).build();
+        PinDeleteRes pinDeleteRes = new PinDeleteRes();
+        when(pinService.deletePin(any())).thenReturn(pinDeleteRes);
+        this.mockMvc
+                .perform(
+                        delete("/v1/pins")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(pinDeleteReq))
+                                .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/pcb/audy/domain/pin/service/PinServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/pin/service/PinServiceTest.java
@@ -1,16 +1,22 @@
 package com.pcb.audy.domain.pin.service;
 
+import static com.pcb.audy.global.response.ResultCode.NOT_FOUND_PIN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.pin.dto.request.PinDeleteReq;
 import com.pcb.audy.domain.pin.dto.request.PinNameUpdateReq;
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.global.exception.GlobalException;
 import com.pcb.audy.global.redis.RedisProvider;
 import com.pcb.audy.test.PinTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -66,5 +72,44 @@ class PinServiceTest implements PinTest {
         // then
         verify(redisProvider).get(any());
         verify(redisProvider).set(any(), any(), anyLong());
+    }
+
+    @Nested
+    class pin_삭제 {
+        @Test
+        @DisplayName("pin 삭제 성공 테스트")
+        void pin_삭제_성공() {
+            // given
+            PinDeleteReq pinDeleteReq =
+                    PinDeleteReq.builder().courseId(TEST_COURSE_ID).pinId(TEST_PIN_ID).build();
+            when(redisProvider.get(any())).thenReturn(TEST_PIN);
+
+            // when
+            pinService.deletePin(pinDeleteReq);
+
+            // then
+            verify(redisProvider).get(any());
+            verify(redisProvider).delete(any());
+        }
+
+        @Test
+        @DisplayName("pin 삭제 실패 테스트")
+        void pin_삭제_실패() {
+            // given
+            PinDeleteReq pinDeleteReq =
+                    PinDeleteReq.builder().courseId(TEST_COURSE_ID).pinId(TEST_PIN_ID).build();
+            when(redisProvider.get(any())).thenReturn(null);
+
+            // when
+            GlobalException exception =
+                    assertThrows(
+                            GlobalException.class,
+                            () -> {
+                                pinService.deletePin(pinDeleteReq);
+                            });
+
+            // then
+            assertThat(exception.getResultCode()).isEqualTo(NOT_FOUND_PIN);
+        }
     }
 }


### PR DESCRIPTION
## 개요
pin 삭제 api를 추가합니다.

## 작업사항
- pin 삭제 api 추가
- 테스트코드 추가
- restdocs에 api 추가

## 관련 이슈
- close #28
