### PR TITLE
카카오 로그인 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 application.yml
+application-prod.yml
 .DS_Store
 
 ### STS ###

--- a/src/main/java/com/pcb/audy/global/security/SecurityConfig.java
+++ b/src/main/java/com/pcb/audy/global/security/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
 
     @Bean
     public OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
-        return new OAuth2AuthenticationSuccessHandler(jwtUtils, redisProvider, objectMapper);
+        return new OAuth2AuthenticationSuccessHandler(jwtUtils, redisProvider);
     }
 
     @Bean


### PR DESCRIPTION
## 개요
카카오 로그인 방식을 수정합니다.

## 작업사항
- token을 쿠키에 넣는 방식으로 변경
- 로그인 성공시 fe url로 redirect
- gitignore에 prod.yml 추가

## 관련 이슈
- close #39 
