### PR TITLE
유저 정보 조회 api 수정

### DIFF
--- a/src/main/java/com/pcb/audy/domain/user/controller/UserController.java
+++ b/src/main/java/com/pcb/audy/domain/user/controller/UserController.java
@@ -2,8 +2,10 @@ package com.pcb.audy.domain.user.controller;
 
 import com.pcb.audy.domain.user.dto.response.UserGetRes;
 import com.pcb.audy.domain.user.service.UserService;
+import com.pcb.audy.global.auth.PrincipalDetails;
 import com.pcb.audy.global.response.BasicResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,7 +18,13 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping
-    public BasicResponse<UserGetRes> getUser(@RequestParam Long userId) {
+    public BasicResponse<UserGetRes> getUser(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestParam(required = false) Long userId) {
+        if (userId == null) {
+            userId = principalDetails.getUser().getUserId();
+        }
+
         return BasicResponse.success(userService.getUser(userId));
     }
 }


### PR DESCRIPTION
## 개요
param에 데이터가 없다면 token으로 가져온 유저 정보를 조회하도록 수정합니다.

## 작업사항
- userId가 없다면 token으로 가져온 유저 정보를 조회하도록 수정

## 관련 이슈
- close #57 
