### PR TITLE
token 관리를 cookie로 변경

### DIFF
--- a/src/main/java/com/pcb/audy/global/jwt/AuthorizationFilter.java
+++ b/src/main/java/com/pcb/audy/global/jwt/AuthorizationFilter.java
@@ -1,7 +1,7 @@
 package com.pcb.audy.global.jwt;
 
-import static com.pcb.audy.global.jwt.JwtUtils.ACCESS_TOKEN_HEADER;
-import static com.pcb.audy.global.jwt.JwtUtils.REFRESH_TOKEN_HEADER;
+import static com.pcb.audy.global.jwt.JwtUtils.ACCESS_TOKEN_NAME;
+import static com.pcb.audy.global.jwt.JwtUtils.REFRESH_TOKEN_NAME;
 import static com.pcb.audy.global.jwt.JwtUtils.TOKEN_TYPE;
 import static com.pcb.audy.global.response.ResultCode.INVALID_TOKEN;
 
@@ -40,8 +40,8 @@ public class AuthorizationFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
-        String accessHeader = request.getHeader(ACCESS_TOKEN_HEADER);
-        String refreshHeader = request.getHeader(REFRESH_TOKEN_HEADER);
+        String accessHeader = request.getHeader(ACCESS_TOKEN_NAME);
+        String refreshHeader = request.getHeader(REFRESH_TOKEN_NAME);
         if (!isExistHeader(accessHeader)) {
             throw new GlobalException(INVALID_TOKEN);
         }
@@ -86,8 +86,8 @@ public class AuthorizationFilter extends OncePerRequestFilter {
             throw new GlobalException(INVALID_TOKEN);
         }
 
-        jwtUtils.updateAccessToken(response, email);
-        jwtUtils.updateRefreshToken(response, email);
+        jwtUtils.setAccessToken(response, email);
+        jwtUtils.setRefreshToken(response, email);
     }
 
     private static boolean isExistHeader(String header) {

--- a/src/main/java/com/pcb/audy/global/security/SecurityConfig.java
+++ b/src/main/java/com/pcb/audy/global/security/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
 
     @Bean
     public OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
-        return new OAuth2AuthenticationSuccessHandler(jwtUtils, redisProvider);
+        return new OAuth2AuthenticationSuccessHandler(jwtUtils);
     }
 
     @Bean

--- a/src/main/java/com/pcb/audy/global/socket/handler/SocketHandler.java
+++ b/src/main/java/com/pcb/audy/global/socket/handler/SocketHandler.java
@@ -19,7 +19,7 @@ public class SocketHandler implements ChannelInterceptor {
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
-        String authorization = accessor.getFirstNativeHeader(JwtUtils.ACCESS_TOKEN_HEADER);
+        String authorization = accessor.getFirstNativeHeader(JwtUtils.ACCESS_TOKEN_NAME);
         String token = authorization.replace(JwtUtils.TOKEN_TYPE, "");
 
         if (accessor.getCommand().equals(StompCommand.CONNECT)) {


### PR DESCRIPTION
## 개요
token을 cookie로 관리하도록 수정합니다.

## 작업사항
- api 요청 시 cookie에서 token을 가져오도록 수정
- token 발급 시 cookie에 담아서 보내도록 수정

## 관련 이슈
- close #58 
