### PR TITLE
editor 저장 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -43,3 +43,7 @@ include::{snippets}/course-controller-test/course_상세_조회/auto-section.ado
 include::{snippets}/course-controller-test/course_전체_조회/auto-section.adoc[]
 include::{snippets}/course-controller-test/관리자_course_전체_조회/auto-section.adoc[]
 include::{snippets}/course-controller-test/멤버_course_전체_조회/auto-section.adoc[]
+
+== editor API
+
+include::{snippets}/editor-controller-test/editor_저장/auto-section.adoc[]

--- a/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
+++ b/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
@@ -16,4 +16,12 @@ public class CourseInviteRedisReq {
         this.userId = userId;
         this.courseId = courseId;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof CourseInviteReq)) return false;
+        CourseInviteRedisReq courseInviteRedisReq = (CourseInviteRedisReq) o;
+        return courseInviteRedisReq.getUserId().equals(this.userId)
+                && courseInviteRedisReq.getCourseId().equals(this.courseId);
+    }
 }

--- a/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
+++ b/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
@@ -19,7 +19,6 @@ public class CourseInviteRedisReq {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof CourseInviteReq)) return false;
         CourseInviteRedisReq courseInviteRedisReq = (CourseInviteRedisReq) o;
         return courseInviteRedisReq.getUserId().equals(this.userId)
                 && courseInviteRedisReq.getCourseId().equals(this.courseId);

--- a/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
+++ b/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
@@ -19,6 +19,7 @@ public class CourseInviteRedisReq {
 
     @Override
     public boolean equals(Object o) {
+        if (!(o instanceof CourseInviteRedisReq)) return false;
         CourseInviteRedisReq courseInviteRedisReq = (CourseInviteRedisReq) o;
         return courseInviteRedisReq.getUserId().equals(this.userId)
                 && courseInviteRedisReq.getCourseId().equals(this.courseId);

--- a/src/main/java/com/pcb/audy/domain/editor/controller/EditorController.java
+++ b/src/main/java/com/pcb/audy/domain/editor/controller/EditorController.java
@@ -1,0 +1,28 @@
+package com.pcb.audy.domain.editor.controller;
+
+import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
+import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
+import com.pcb.audy.domain.editor.service.EditorService;
+import com.pcb.audy.global.auth.PrincipalDetails;
+import com.pcb.audy.global.response.BasicResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/editors")
+@RequiredArgsConstructor
+public class EditorController {
+    private final EditorService editorService;
+
+    @PostMapping
+    public BasicResponse<EditorSaveRes> saveEditor(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody EditorSaveReq editorSaveReq) {
+        editorSaveReq.setUserId(principalDetails.getUser().getUserId());
+        return BasicResponse.success(editorService.saveEditor(editorSaveReq));
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/editor/controller/EditorController.java
+++ b/src/main/java/com/pcb/audy/domain/editor/controller/EditorController.java
@@ -1,16 +1,16 @@
 package com.pcb.audy.domain.editor.controller;
 
-import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
-import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
 import com.pcb.audy.domain.editor.dto.request.EditorRoleUpdateReq;
+import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
 import com.pcb.audy.domain.editor.dto.response.EditorRoleUpdateRes;
+import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
 import com.pcb.audy.domain.editor.service.EditorService;
 import com.pcb.audy.global.auth.PrincipalDetails;
 import com.pcb.audy.global.response.BasicResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +27,7 @@ public class EditorController {
             @RequestBody EditorSaveReq editorSaveReq) {
         editorSaveReq.setUserId(principalDetails.getUser().getUserId());
         return BasicResponse.success(editorService.saveEditor(editorSaveReq));
+    }
 
     @PatchMapping
     public BasicResponse<EditorRoleUpdateRes> updateEditorRole(

--- a/src/main/java/com/pcb/audy/domain/editor/dto/request/EditorSaveReq.java
+++ b/src/main/java/com/pcb/audy/domain/editor/dto/request/EditorSaveReq.java
@@ -11,12 +11,10 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EditorSaveReq {
     private Long userId;
-    private Long courseId;
     private String key;
 
     @Builder
-    private EditorSaveReq(Long courseId, String key) {
-        this.courseId = courseId;
+    private EditorSaveReq(String key) {
         this.key = key;
     }
 }

--- a/src/main/java/com/pcb/audy/domain/editor/dto/request/EditorSaveReq.java
+++ b/src/main/java/com/pcb/audy/domain/editor/dto/request/EditorSaveReq.java
@@ -1,0 +1,22 @@
+package com.pcb.audy.domain.editor.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EditorSaveReq {
+    private Long userId;
+    private Long courseId;
+    private String key;
+
+    @Builder
+    private EditorSaveReq(Long courseId, String key) {
+        this.courseId = courseId;
+        this.key = key;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/editor/dto/response/EditorSaveRes.java
+++ b/src/main/java/com/pcb/audy/domain/editor/dto/response/EditorSaveRes.java
@@ -1,6 +1,17 @@
 package com.pcb.audy.domain.editor.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@JsonIgnoreProperties
-public class EditorSaveRes {}
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EditorSaveRes {
+    private Long courseId;
+
+    @Builder
+    private EditorSaveRes(Long courseId) {
+        this.courseId = courseId;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/editor/dto/response/EditorSaveRes.java
+++ b/src/main/java/com/pcb/audy/domain/editor/dto/response/EditorSaveRes.java
@@ -1,0 +1,6 @@
+package com.pcb.audy.domain.editor.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class EditorSaveRes {}

--- a/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
+++ b/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
@@ -56,8 +56,9 @@ public class EditorService {
         User user = getUserByUserId(editorSaveReq.getUserId());
         checkAlreadyExistEditor(user, course);
 
-        editorRepository.save(Editor.builder().user(user).course(course).role(MEMBER).build());
-        return new EditorSaveRes();
+        Editor savedEditor =
+                editorRepository.save(Editor.builder().user(user).course(course).role(MEMBER).build());
+        return EditorServiceMapper.INSTANCE.toEditorSaveRes(savedEditor);
     }
 
     private void checkAlreadyExistEditor(User user, Course course) {

--- a/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
+++ b/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
@@ -47,7 +47,7 @@ public class EditorService {
                 objectMapper.convertValue(
                         redisProvider.get(INVITE_PREFIX + courseInviteRedisReq.getCourseId()),
                         CourseInviteRedisReq.class);
-        EditorValidator.validateObject(courseInviteRedisReq, findByKey);
+        EditorValidator.checkValidateObject(courseInviteRedisReq, findByKey);
 
         // 초대 링크 상의 course가 유효한 지 검증
         Course course = getCourseByCourseId(courseInviteRedisReq.getCourseId());

--- a/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
+++ b/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
@@ -1,0 +1,59 @@
+package com.pcb.audy.domain.editor.service;
+
+import static com.pcb.audy.global.meta.Role.MEMBER;
+
+import com.pcb.audy.domain.course.entity.Course;
+import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
+import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
+import com.pcb.audy.domain.editor.entity.Editor;
+import com.pcb.audy.domain.editor.repository.EditorRepository;
+import com.pcb.audy.domain.user.entity.User;
+import com.pcb.audy.domain.user.repository.UserRepository;
+import com.pcb.audy.global.redis.RedisProvider;
+import com.pcb.audy.global.validator.CourseValidator;
+import com.pcb.audy.global.validator.EditorValidator;
+import com.pcb.audy.global.validator.UserValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EditorService {
+    private final RedisProvider redisProvider;
+    private final EditorRepository editorRepository;
+    private final UserRepository userRepository;
+    private final CourseRepository courseRepository;
+
+    private static final String INVITE_PREFIX = "invite:";
+
+    @Transactional
+    public EditorSaveRes saveEditor(EditorSaveReq editorSaveReq) {
+        EditorValidator.validateKey(
+                editorSaveReq.getKey(),
+                (String) redisProvider.get(INVITE_PREFIX + editorSaveReq.getCourseId()));
+        User user = getUserByUserId(editorSaveReq.getUserId());
+        Course course = getCourseByCourseId(editorSaveReq.getCourseId());
+        checkAlreadyExistEditor(user, course);
+        editorRepository.save(Editor.builder().user(user).course(course).role(MEMBER).build());
+        return new EditorSaveRes();
+    }
+
+    private void checkAlreadyExistEditor(User user, Course course) {
+        Editor editor = editorRepository.findByUserAndCourse(user, course);
+        EditorValidator.checkAlreadyExist(editor);
+    }
+
+    private User getUserByUserId(Long userId) {
+        User user = userRepository.findByUserId(userId);
+        UserValidator.validate(user);
+        return user;
+    }
+
+    private Course getCourseByCourseId(Long courseId) {
+        Course course = courseRepository.findByCourseId(courseId);
+        CourseValidator.validate(course);
+        return course;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
+++ b/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
@@ -4,10 +4,10 @@ import static com.pcb.audy.global.meta.Role.MEMBER;
 
 import com.pcb.audy.domain.course.entity.Course;
 import com.pcb.audy.domain.course.repository.CourseRepository;
-import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
-import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
 import com.pcb.audy.domain.editor.dto.request.EditorRoleUpdateReq;
+import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
 import com.pcb.audy.domain.editor.dto.response.EditorRoleUpdateRes;
+import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
 import com.pcb.audy.domain.editor.entity.Editor;
 import com.pcb.audy.domain.editor.repository.EditorRepository;
 import com.pcb.audy.domain.user.entity.User;
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class EditorService {
-  
+
     private final RedisProvider redisProvider;
     private final EditorRepository editorRepository;
     private final UserRepository userRepository;
@@ -47,7 +47,7 @@ public class EditorService {
         Editor editor = editorRepository.findByUserAndCourse(user, course);
         EditorValidator.checkAlreadyExist(editor);
     }
-  
+
     @Transactional
     public EditorRoleUpdateRes updateRoleEditor(EditorRoleUpdateReq editorRoleUpdateReq) {
         User user = getUserByUserId(editorRoleUpdateReq.getUserId());

--- a/src/main/java/com/pcb/audy/domain/editor/service/EditorServiceMapper.java
+++ b/src/main/java/com/pcb/audy/domain/editor/service/EditorServiceMapper.java
@@ -1,0 +1,15 @@
+package com.pcb.audy.domain.editor.service;
+
+import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
+import com.pcb.audy.domain.editor.entity.Editor;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface EditorServiceMapper {
+    EditorServiceMapper INSTANCE = Mappers.getMapper(EditorServiceMapper.class);
+
+    @Mapping(target = "courseId", expression = "java(editor.getCourse().getCourseId())")
+    EditorSaveRes toEditorSaveRes(Editor editor);
+}

--- a/src/main/java/com/pcb/audy/global/response/ResultCode.java
+++ b/src/main/java/com/pcb/audy/global/response/ResultCode.java
@@ -22,7 +22,7 @@ public enum ResultCode {
     NOT_FOUND_PIN(4000, "핀을 찾을 수 없습니다."),
 
     NOT_FOUND_EDITOR(5000, "에디터를 찾을 수 없습니다."),
-    VALID_KEY(5001, "올바르지 않은 키입니다."),
+    NOT_VALID_KEY(5001, "유효기간이 만료된 링크입니다."),
     ALREADY_EXIST_EDITOR(5002, "이미 코스에 포함된 멤버입니다."),
 
     FAILED_ENCRYPT(6000, "객체 암호화에 실패하였습니다."),

--- a/src/main/java/com/pcb/audy/global/response/ResultCode.java
+++ b/src/main/java/com/pcb/audy/global/response/ResultCode.java
@@ -21,7 +21,9 @@ public enum ResultCode {
 
     NOT_FOUND_PIN(4000, "핀을 찾을 수 없습니다."),
 
-    NOT_FOUND_EDITOR(5000, "에디터를 찾을 수 없습니다.");
+    NOT_FOUND_EDITOR(5000, "에디터를 찾을 수 없습니다."),
+    VALID_KEY(5001, "올바르지 않은 키입니다."),
+    ALREADY_EXIST_EDITOR(5002, "이미 코스에 포함된 멤버입니다.");
 
     private Integer code;
     private String message;

--- a/src/main/java/com/pcb/audy/global/response/ResultCode.java
+++ b/src/main/java/com/pcb/audy/global/response/ResultCode.java
@@ -23,7 +23,7 @@ public enum ResultCode {
 
     NOT_FOUND_EDITOR(5000, "에디터를 찾을 수 없습니다."),
     VALID_KEY(5001, "올바르지 않은 키입니다."),
-    ALREADY_EXIST_EDITOR(5002, "이미 코스에 포함된 멤버입니다.");
+    ALREADY_EXIST_EDITOR(5002, "이미 코스에 포함된 멤버입니다."),
 
     FAILED_ENCRYPT(6000, "객체 암호화에 실패하였습니다."),
     FAILED_DECRYPT(6001, "객체 복호화에 실패하였습니다.");

--- a/src/main/java/com/pcb/audy/global/util/InviteUtil.java
+++ b/src/main/java/com/pcb/audy/global/util/InviteUtil.java
@@ -51,7 +51,7 @@ public class InviteUtil {
             byte[] decryptedBytes = cipher.doFinal(decodedBytes);
 
             // 복호화된 데이터를 JSON 문자열로 변환
-            String json = decryptedBytes.toString();
+            String json = new String(decryptedBytes);
 
             // JSON 문자열을 CourseInviteReq 객체로 변환
             return objectMapper.readValue(json, CourseInviteRedisReq.class);

--- a/src/main/java/com/pcb/audy/global/validator/EditorValidator.java
+++ b/src/main/java/com/pcb/audy/global/validator/EditorValidator.java
@@ -5,6 +5,7 @@ import static com.pcb.audy.global.response.ResultCode.*;
 import com.pcb.audy.domain.editor.entity.Editor;
 import com.pcb.audy.global.exception.GlobalException;
 import com.pcb.audy.global.meta.Role;
+import org.springframework.util.StringUtils;
 
 public class EditorValidator {
 
@@ -24,11 +25,31 @@ public class EditorValidator {
         }
     }
 
+    public static void validateKey(String key, String findKey) {
+        if (!isExistKey(key) || !isMatchedKey(key, findKey)) {
+            throw new GlobalException(VALID_KEY);
+        }
+    }
+
+    public static void checkAlreadyExist(Editor editor) {
+        if (isExistEditor(editor)) {
+            throw new GlobalException(ALREADY_EXIST_EDITOR);
+        }
+    }
+
+    private static boolean isExistKey(String key) {
+        return StringUtils.hasText(key);
+    }
+
     private static boolean isExistEditor(Editor editor) {
         return editor != null;
     }
 
     private static boolean isAdminEditor(Editor editor) {
         return Role.OWNER.equals(editor.getRole());
+    }
+
+    private static boolean isMatchedKey(String key, String findKey) {
+        return key.equals(findKey);
     }
 }

--- a/src/main/java/com/pcb/audy/global/validator/EditorValidator.java
+++ b/src/main/java/com/pcb/audy/global/validator/EditorValidator.java
@@ -2,11 +2,17 @@ package com.pcb.audy.global.validator;
 
 import static com.pcb.audy.global.response.ResultCode.*;
 
+import com.pcb.audy.domain.course.dto.request.CourseInviteRedisReq;
 import com.pcb.audy.domain.editor.entity.Editor;
 import com.pcb.audy.global.exception.GlobalException;
 import com.pcb.audy.global.meta.Role;
+import com.pcb.audy.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+@Component
+@RequiredArgsConstructor
 public class EditorValidator {
 
     public static void validate(Editor editor) {
@@ -22,12 +28,6 @@ public class EditorValidator {
 
         if (!isAdminEditor(editor)) {
             throw new GlobalException(NOT_ADMIN_COURSE);
-        }
-    }
-
-    public static void validateKey(String key, String findKey) {
-        if (!isExistKey(key) || !isMatchedKey(key, findKey)) {
-            throw new GlobalException(VALID_KEY);
         }
     }
 
@@ -51,5 +51,12 @@ public class EditorValidator {
 
     private static boolean isMatchedKey(String key, String findKey) {
         return key.equals(findKey);
+    }
+
+    public static void validateObject(
+            CourseInviteRedisReq courseInviteRedisReq, CourseInviteRedisReq findByKey) {
+        if (!courseInviteRedisReq.equals(findByKey)) {
+            throw new GlobalException(ResultCode.NOT_VALID_KEY);
+        }
     }
 }

--- a/src/main/java/com/pcb/audy/global/validator/EditorValidator.java
+++ b/src/main/java/com/pcb/audy/global/validator/EditorValidator.java
@@ -7,12 +7,8 @@ import com.pcb.audy.domain.editor.entity.Editor;
 import com.pcb.audy.global.exception.GlobalException;
 import com.pcb.audy.global.meta.Role;
 import com.pcb.audy.global.response.ResultCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-@Component
-@RequiredArgsConstructor
 public class EditorValidator {
 
     public static void validate(Editor editor) {
@@ -37,6 +33,13 @@ public class EditorValidator {
         }
     }
 
+    public static void checkValidateObject(
+            CourseInviteRedisReq courseInviteRedisReq, CourseInviteRedisReq findByKey) {
+        if (!isEqualObject(courseInviteRedisReq, findByKey)) {
+            throw new GlobalException(ResultCode.NOT_VALID_KEY);
+        }
+    }
+
     private static boolean isExistKey(String key) {
         return StringUtils.hasText(key);
     }
@@ -49,14 +52,8 @@ public class EditorValidator {
         return Role.OWNER.equals(editor.getRole());
     }
 
-    private static boolean isMatchedKey(String key, String findKey) {
-        return key.equals(findKey);
-    }
-
-    public static void validateObject(
+    private static boolean isEqualObject(
             CourseInviteRedisReq courseInviteRedisReq, CourseInviteRedisReq findByKey) {
-        if (!courseInviteRedisReq.equals(findByKey)) {
-            throw new GlobalException(ResultCode.NOT_VALID_KEY);
-        }
+        return courseInviteRedisReq.equals(findByKey);
     }
 }

--- a/src/test/java/com/pcb/audy/domain/editor/controller/EditorControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/editor/controller/EditorControllerTest.java
@@ -1,19 +1,18 @@
 package com.pcb.audy.domain.editor.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static com.pcb.audy.global.meta.Role.MEMBER;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.pcb.audy.domain.BaseMvcTest;
-import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
-import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
 import com.pcb.audy.domain.editor.dto.request.EditorRoleUpdateReq;
+import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
 import com.pcb.audy.domain.editor.dto.response.EditorRoleUpdateRes;
+import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
 import com.pcb.audy.domain.editor.service.EditorService;
 import com.pcb.audy.test.EditorTest;
 import org.junit.jupiter.api.DisplayName;
@@ -42,7 +41,7 @@ class EditorControllerTest extends BaseMvcTest implements EditorTest {
                 .andDo(print())
                 .andExpect(status().isOk());
     }
-  
+
     @Test
     @DisplayName("editor 역할 수정 테스트")
     void editor_역할_수정() throws Exception {

--- a/src/test/java/com/pcb/audy/domain/editor/controller/EditorControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/editor/controller/EditorControllerTest.java
@@ -1,0 +1,40 @@
+package com.pcb.audy.domain.editor.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.pcb.audy.domain.BaseMvcTest;
+import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
+import com.pcb.audy.domain.editor.dto.response.EditorSaveRes;
+import com.pcb.audy.domain.editor.service.EditorService;
+import com.pcb.audy.test.EditorTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(controllers = {EditorController.class})
+class EditorControllerTest extends BaseMvcTest implements EditorTest {
+    @MockBean private EditorService editorService;
+
+    @Test
+    @DisplayName("editor 저장 테스트")
+    void editor_저장() throws Exception {
+        EditorSaveReq editorSaveReq =
+                EditorSaveReq.builder().courseId(TEST_COURSE_ID).key(TEST_KEY).build();
+        EditorSaveRes editorSaveRes = new EditorSaveRes();
+        when(editorService.saveEditor(any())).thenReturn(editorSaveRes);
+        this.mockMvc
+                .perform(
+                        post("/v1/editors")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(editorSaveReq))
+                                .principal(this.mockPrincipal))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/editor/controller/EditorControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/editor/controller/EditorControllerTest.java
@@ -3,8 +3,8 @@ package com.pcb.audy.domain.editor.controller;
 import static com.pcb.audy.global.meta.Role.MEMBER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -28,9 +28,8 @@ class EditorControllerTest extends BaseMvcTest implements EditorTest {
     @Test
     @DisplayName("editor 저장 테스트")
     void editor_저장() throws Exception {
-        EditorSaveReq editorSaveReq =
-                EditorSaveReq.builder().courseId(TEST_COURSE_ID).key(TEST_KEY).build();
-        EditorSaveRes editorSaveRes = new EditorSaveRes();
+        EditorSaveReq editorSaveReq = EditorSaveReq.builder().key(TEST_KEY).build();
+        EditorSaveRes editorSaveRes = EditorSaveRes.builder().courseId(TEST_COURSE_ID).build();
         when(editorService.saveEditor(any())).thenReturn(editorSaveRes);
         this.mockMvc
                 .perform(

--- a/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
@@ -1,0 +1,101 @@
+package com.pcb.audy.domain.editor.service;
+
+import static com.pcb.audy.global.response.ResultCode.ALREADY_EXIST_EDITOR;
+import static com.pcb.audy.global.response.ResultCode.VALID_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
+import com.pcb.audy.domain.editor.repository.EditorRepository;
+import com.pcb.audy.domain.user.repository.UserRepository;
+import com.pcb.audy.global.exception.GlobalException;
+import com.pcb.audy.global.redis.RedisProvider;
+import com.pcb.audy.test.EditorTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EditorServiceTest implements EditorTest {
+    @InjectMocks private EditorService editorService;
+    @Mock private RedisProvider redisProvider;
+    @Mock private EditorRepository editorRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private CourseRepository courseRepository;
+
+    @Nested
+    class editor_저장 {
+        @Test
+        @DisplayName("editor 저장 테스트")
+        void editor_저장() {
+            // given
+            EditorSaveReq editorSaveReq =
+                    EditorSaveReq.builder().courseId(TEST_COURSE_ID).key(TEST_KEY).build();
+            when(redisProvider.get(any())).thenReturn(TEST_KEY);
+            when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
+            when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
+            when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(null);
+
+            // when
+            editorService.saveEditor(editorSaveReq);
+
+            // then
+            verify(redisProvider).get(any());
+            verify(userRepository).findByUserId(any());
+            verify(courseRepository).findByCourseId(any());
+            verify(editorRepository).findByUserAndCourse(any(), any());
+            verify(editorRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("editor 저장 실패 테스트 (key match)")
+        void editor_저장_실패_key_match() {
+            // given
+            EditorSaveReq editorSaveReq =
+                    EditorSaveReq.builder().courseId(TEST_COURSE_ID).key(TEST_ANOTHER_KEY).build();
+            when(redisProvider.get(any())).thenReturn(TEST_KEY);
+
+            // when
+            GlobalException exception =
+                    assertThrows(
+                            GlobalException.class,
+                            () -> {
+                                editorService.saveEditor(editorSaveReq);
+                            });
+
+            // then
+            assertThat(exception.getResultCode()).isEqualTo(VALID_KEY);
+        }
+
+        @Test
+        @DisplayName("editor 저장 실패 테스트 (already exist)")
+        void editor_저장_실패_already_exist() {
+            // given
+            EditorSaveReq editorSaveReq =
+                    EditorSaveReq.builder().courseId(TEST_COURSE_ID).key(TEST_KEY).build();
+            when(redisProvider.get(any())).thenReturn(TEST_KEY);
+            when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
+            when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
+            when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(TEST_EDITOR_MEMBER);
+
+            // when
+            GlobalException exception =
+                    assertThrows(
+                            GlobalException.class,
+                            () -> {
+                                editorService.saveEditor(editorSaveReq);
+                            });
+
+            // then
+            assertThat(exception.getResultCode()).isEqualTo(ALREADY_EXIST_EDITOR);
+        }
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
@@ -1,16 +1,17 @@
 package com.pcb.audy.domain.editor.service;
 
 import static com.pcb.audy.global.meta.Role.MEMBER;
-import static com.pcb.audy.global.response.ResultCode.ALREADY_EXIST_EDITOR;
-import static com.pcb.audy.global.response.ResultCode.NOT_ADMIN_COURSE;
-import static com.pcb.audy.global.response.ResultCode.VALID_KEY;
+import static com.pcb.audy.global.response.ResultCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pcb.audy.domain.course.dto.request.CourseInviteRedisReq;
 import com.pcb.audy.domain.course.repository.CourseRepository;
 import com.pcb.audy.domain.editor.dto.request.EditorRoleUpdateReq;
 import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
@@ -18,6 +19,7 @@ import com.pcb.audy.domain.editor.repository.EditorRepository;
 import com.pcb.audy.domain.user.repository.UserRepository;
 import com.pcb.audy.global.exception.GlobalException;
 import com.pcb.audy.global.redis.RedisProvider;
+import com.pcb.audy.global.util.InviteUtil;
 import com.pcb.audy.test.EditorTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -35,6 +37,8 @@ class EditorServiceTest implements EditorTest {
     @Mock private EditorRepository editorRepository;
     @Mock private UserRepository userRepository;
     @Mock private CourseRepository courseRepository;
+    @Mock private ObjectMapper objectMapper;
+    @Mock private InviteUtil inviteUtil;
 
     @Nested
     class editor_저장 {
@@ -42,9 +46,12 @@ class EditorServiceTest implements EditorTest {
         @DisplayName("editor 저장 테스트")
         void editor_저장() {
             // given
-            EditorSaveReq editorSaveReq =
-                    EditorSaveReq.builder().courseId(TEST_COURSE_ID).key(TEST_KEY).build();
-            when(redisProvider.get(any())).thenReturn(TEST_KEY);
+            EditorSaveReq editorSaveReq = EditorSaveReq.builder().key(TEST_KEY).build();
+
+            when(inviteUtil.decryptCourseInviteReq(any())).thenReturn(TEST_COURSE_INVITE_REDIS_REQ);
+            when(redisProvider.get(any())).thenReturn(TEST_COURSE_INVITE_REDIS_REQ);
+            when(objectMapper.convertValue(any(), eq(CourseInviteRedisReq.class)))
+                    .thenReturn(TEST_COURSE_INVITE_REDIS_REQ);
             when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
             when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
             when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(null);
@@ -53,7 +60,9 @@ class EditorServiceTest implements EditorTest {
             editorService.saveEditor(editorSaveReq);
 
             // then
+            verify(inviteUtil).decryptCourseInviteReq(any());
             verify(redisProvider).get(any());
+            verify(objectMapper).convertValue(any(), eq(CourseInviteRedisReq.class));
             verify(userRepository).findByUserId(any());
             verify(courseRepository).findByCourseId(any());
             verify(editorRepository).findByUserAndCourse(any(), any());
@@ -61,12 +70,13 @@ class EditorServiceTest implements EditorTest {
         }
 
         @Test
-        @DisplayName("editor 저장 실패 테스트 (key match)")
+        @DisplayName("editor 저장 실패 테스트 (key 존재하지 않을 때)")
         void editor_저장_실패_key_match() {
             // given
-            EditorSaveReq editorSaveReq =
-                    EditorSaveReq.builder().courseId(TEST_COURSE_ID).key(TEST_ANOTHER_KEY).build();
-            when(redisProvider.get(any())).thenReturn(TEST_KEY);
+            EditorSaveReq editorSaveReq = EditorSaveReq.builder().key(TEST_ANOTHER_KEY).build();
+
+            when(inviteUtil.decryptCourseInviteReq(any())).thenReturn(TEST_COURSE_INVITE_REDIS_REQ);
+            when(redisProvider.get(any())).thenReturn(null);
 
             // when
             GlobalException exception =
@@ -78,18 +88,22 @@ class EditorServiceTest implements EditorTest {
 
             // then
             verify(redisProvider).get(any());
-            assertThat(exception.getResultCode()).isEqualTo(VALID_KEY);
+            assertThat(exception.getResultCode()).isEqualTo(NOT_VALID_KEY);
         }
 
         @Test
         @DisplayName("editor 저장 실패 테스트 (already exist)")
         void editor_저장_실패_already_exist() {
             // given
-            EditorSaveReq editorSaveReq =
-                    EditorSaveReq.builder().courseId(TEST_COURSE_ID).key(TEST_KEY).build();
-            when(redisProvider.get(any())).thenReturn(TEST_KEY);
+            EditorSaveReq editorSaveReq = EditorSaveReq.builder().key(TEST_KEY).build();
+
+            when(inviteUtil.decryptCourseInviteReq(any())).thenReturn(TEST_COURSE_INVITE_REDIS_REQ);
+            when(redisProvider.get(any())).thenReturn(TEST_COURSE_INVITE_REDIS_REQ);
+            when(objectMapper.convertValue(any(), eq(CourseInviteRedisReq.class)))
+                    .thenReturn(TEST_COURSE_INVITE_REDIS_REQ);
             when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
             when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
+
             when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(TEST_EDITOR_MEMBER);
 
             // when

--- a/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
@@ -72,6 +72,7 @@ class EditorServiceTest implements EditorTest {
                             });
 
             // then
+            verify(redisProvider).get(any());
             assertThat(exception.getResultCode()).isEqualTo(VALID_KEY);
         }
 
@@ -95,6 +96,10 @@ class EditorServiceTest implements EditorTest {
                             });
 
             // then
+            verify(redisProvider).get(any());
+            verify(userRepository).findByUserId(any());
+            verify(courseRepository).findByCourseId(any());
+            verify(editorRepository).findByUserAndCourse(any(), any());
             assertThat(exception.getResultCode()).isEqualTo(ALREADY_EXIST_EDITOR);
         }
     }

--- a/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
@@ -1,21 +1,23 @@
 package com.pcb.audy.domain.editor.service;
 
-import static com.pcb.audy.global.response.ResultCode.ALREADY_EXIST_EDITOR;
-import static com.pcb.audy.global.response.ResultCode.VALID_KEY;
 import static com.pcb.audy.global.meta.Role.MEMBER;
+import static com.pcb.audy.global.response.ResultCode.ALREADY_EXIST_EDITOR;
 import static com.pcb.audy.global.response.ResultCode.NOT_ADMIN_COURSE;
+import static com.pcb.audy.global.response.ResultCode.VALID_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
-
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.pcb.audy.domain.course.repository.CourseRepository;
-import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
-import com.pcb.audy.global.redis.RedisProvider;
 import com.pcb.audy.domain.editor.dto.request.EditorRoleUpdateReq;
+import com.pcb.audy.domain.editor.dto.request.EditorSaveReq;
+import com.pcb.audy.domain.editor.repository.EditorRepository;
+import com.pcb.audy.domain.user.repository.UserRepository;
+import com.pcb.audy.global.exception.GlobalException;
+import com.pcb.audy.global.redis.RedisProvider;
 import com.pcb.audy.test.EditorTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -106,8 +108,8 @@ class EditorServiceTest implements EditorTest {
             assertThat(exception.getResultCode()).isEqualTo(ALREADY_EXIST_EDITOR);
         }
     }
-  
-  @Nested
+
+    @Nested
     class editor_역할_수정 {
         @Test
         @DisplayName("editor 역할 수정 테스트")

--- a/src/test/java/com/pcb/audy/test/CourseTest.java
+++ b/src/test/java/com/pcb/audy/test/CourseTest.java
@@ -1,5 +1,8 @@
 package com.pcb.audy.test;
 
+import static com.pcb.audy.test.UserTest.TEST_USER_ID;
+
+import com.pcb.audy.domain.course.dto.request.CourseInviteRedisReq;
 import com.pcb.audy.domain.course.entity.Course;
 
 public interface CourseTest {
@@ -18,4 +21,7 @@ public interface CourseTest {
 
     Course TEST_SECOND_COURSE =
             Course.builder().courseId(TEST_SECOND_COURSE_ID).courseName(TEST_SECOND_COURSE_NAME).build();
+
+    CourseInviteRedisReq TEST_COURSE_INVITE_REDIS_REQ =
+            CourseInviteRedisReq.builder().courseId(TEST_COURSE_ID).userId(TEST_USER_ID).build();
 }

--- a/src/test/java/com/pcb/audy/test/EditorTest.java
+++ b/src/test/java/com/pcb/audy/test/EditorTest.java
@@ -1,11 +1,11 @@
 package com.pcb.audy.test;
 
-import static com.pcb.audy.test.UserTest.TEST_USER;
-
 import com.pcb.audy.domain.editor.entity.Editor;
 import com.pcb.audy.global.meta.Role;
 
-public interface EditorTest extends CourseTest {
+public interface EditorTest extends CourseTest, UserTest {
+    String TEST_KEY = "key";
+    String TEST_ANOTHER_KEY = "anotherKey";
 
     Editor TEST_EDITOR_ADMIN =
             Editor.builder().course(TEST_COURSE).user(TEST_USER).role(Role.OWNER).build();


### PR DESCRIPTION
## 개요
editor 저장 api를 추가합니다.

## 작업사항
- editor 저장 api 추가
- 테스트코드 추가
- restdocs에 api 추가

## 관련 이슈
- close #72 
