### PR TITLE
코스 초대 API 변경

### DIFF
--- a/src/main/java/com/pcb/audy/domain/course/controller/CourseController.java
+++ b/src/main/java/com/pcb/audy/domain/course/controller/CourseController.java
@@ -46,8 +46,7 @@ public class CourseController {
     @PostMapping("/invite")
     public BasicResponse<CourseInviteRes> inviteCourse(
             @RequestBody CourseInviteReq courseInviteReq,
-            @AuthenticationPrincipal PrincipalDetails userDetails)
-            throws Exception {
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
         courseInviteReq.setUserId(userDetails.getUser().getUserId());
         return BasicResponse.success(courseService.inviteCourse(courseInviteReq));
     }

--- a/src/main/java/com/pcb/audy/domain/course/controller/CourseController.java
+++ b/src/main/java/com/pcb/audy/domain/course/controller/CourseController.java
@@ -46,7 +46,8 @@ public class CourseController {
     @PostMapping("/invite")
     public BasicResponse<CourseInviteRes> inviteCourse(
             @RequestBody CourseInviteReq courseInviteReq,
-            @AuthenticationPrincipal PrincipalDetails userDetails) {
+            @AuthenticationPrincipal PrincipalDetails userDetails)
+            throws Exception {
         courseInviteReq.setUserId(userDetails.getUser().getUserId());
         return BasicResponse.success(courseService.inviteCourse(courseInviteReq));
     }

--- a/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
+++ b/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
@@ -1,0 +1,15 @@
+package com.pcb.audy.domain.course.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseInviteRedisReq {
+    private Long courseId;
+
+    @Builder
+    private CourseInviteRedisReq(Long courseId) {
+        this.courseId = courseId;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
+++ b/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
@@ -2,12 +2,13 @@ package com.pcb.audy.domain.course.dto.request;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseInviteRedisReq {
     private Long courseId;
-
     @Builder
     private CourseInviteRedisReq(Long courseId) {
         this.courseId = courseId;

--- a/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
+++ b/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
@@ -9,8 +9,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseInviteRedisReq {
     private Long courseId;
+    private Long userId;
     @Builder
-    private CourseInviteRedisReq(Long courseId) {
+    private CourseInviteRedisReq(Long userId, Long courseId) {
+        this.userId = userId;
         this.courseId = courseId;
     }
 }

--- a/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
+++ b/src/main/java/com/pcb/audy/domain/course/dto/request/CourseInviteRedisReq.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class CourseInviteRedisReq {
     private Long courseId;
     private Long userId;
+
     @Builder
     private CourseInviteRedisReq(Long userId, Long courseId) {
         this.userId = userId;

--- a/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
+++ b/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
@@ -1,9 +1,6 @@
 package com.pcb.audy.domain.course.service;
 
-import com.pcb.audy.domain.course.dto.request.CourseDeleteReq;
-import com.pcb.audy.domain.course.dto.request.CourseInviteReq;
-import com.pcb.audy.domain.course.dto.request.CourseSaveReq;
-import com.pcb.audy.domain.course.dto.request.CourseUpdateReq;
+import com.pcb.audy.domain.course.dto.request.*;
 import com.pcb.audy.domain.course.dto.response.*;
 import com.pcb.audy.domain.course.entity.Course;
 import com.pcb.audy.domain.course.repository.CourseRepository;
@@ -79,19 +76,19 @@ public class CourseService {
     public CourseInviteRes inviteCourse(CourseInviteReq courseInviteReq) throws Exception {
         // 초대 권한 확인
         User user = getUserByUserId(courseInviteReq.getUserId());
-        System.out.println(user.getUserId());
         Course course = getCourseByCourseId(courseInviteReq.getCourseId());
         isAdminUser(user, course);
 
         // 링크 생성
         String redisKey = INVITE_PREFIX + courseInviteReq.getCourseId();
+        CourseInviteRedisReq courseInviteRedisReq = CourseInviteRedisReq.builder().courseId(courseInviteReq.getCourseId()).build();
 
         if (!redisProvider.hasKey(redisKey)) { // 중복 체크 -> 하지 않으면 기존 코드가 사용 불가능하기 때문
-            redisProvider.set(redisKey, courseInviteReq, INVITE_EXPIRE_TIME);
+            redisProvider.set(redisKey, courseInviteRedisReq, INVITE_EXPIRE_TIME);
         }
 
         return CourseInviteRes.builder()
-                .url(INVITE_DOMAIN + inviteUtil.encryptCourseInviteReq(courseInviteReq))
+                .url(INVITE_DOMAIN + inviteUtil.encryptCourseInviteReq(courseInviteRedisReq))
                 .build();
     }
 

--- a/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
+++ b/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
@@ -73,7 +73,7 @@ public class CourseService {
     }
 
     @Transactional(readOnly = true)
-    public CourseInviteRes inviteCourse(CourseInviteReq courseInviteReq) throws Exception {
+    public CourseInviteRes inviteCourse(CourseInviteReq courseInviteReq) {
         // 초대 권한 확인
         User user = getUserByUserId(courseInviteReq.getUserId());
         Course course = getCourseByCourseId(courseInviteReq.getCourseId());

--- a/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
+++ b/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
@@ -13,12 +13,11 @@ import com.pcb.audy.domain.user.entity.User;
 import com.pcb.audy.domain.user.repository.UserRepository;
 import com.pcb.audy.global.meta.Role;
 import com.pcb.audy.global.redis.RedisProvider;
+import com.pcb.audy.global.util.InviteUtil;
 import com.pcb.audy.global.validator.CourseValidator;
 import com.pcb.audy.global.validator.EditorValidator;
 import com.pcb.audy.global.validator.UserValidator;
-import java.util.Base64;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -33,10 +32,10 @@ public class CourseService {
     private final CourseRepository courseRepository;
     private final EditorRepository editorRepository;
     private final RedisProvider redisProvider;
+    private final InviteUtil inviteUtil;
 
-    public static final String INVITE_PREFIX = "invite:";
-    public static final String COURSE_PREFIX = "course:";
-    public static final String DOMAIN = "https://audy-gakka.com/invite/";
+    private static final String INVITE_PREFIX = "Invite: ";
+    public static final String INVITE_DOMAIN = "https://audy-gakka.com/invite/";
     public static final int INVITE_EXPIRE_TIME = 72 * 60 * 60 * 1000;
 
     @Transactional
@@ -77,23 +76,23 @@ public class CourseService {
     }
 
     @Transactional(readOnly = true)
-    public CourseInviteRes inviteCourse(CourseInviteReq courseInviteReq) {
+    public CourseInviteRes inviteCourse(CourseInviteReq courseInviteReq) throws Exception {
         // 초대 권한 확인
         User user = getUserByUserId(courseInviteReq.getUserId());
+        System.out.println(user.getUserId());
         Course course = getCourseByCourseId(courseInviteReq.getCourseId());
         isAdminUser(user, course);
 
         // 링크 생성
         String redisKey = INVITE_PREFIX + courseInviteReq.getCourseId();
-        String key = (String) redisProvider.get(redisKey);
-        if (key == null) {
-            String before =
-                    COURSE_PREFIX + courseInviteReq.getCourseId() + RandomStringUtils.randomAlphabetic(6);
-            key = Base64.getEncoder().encodeToString(before.getBytes());
-            redisProvider.set(redisKey, key, INVITE_EXPIRE_TIME);
+
+        if (!redisProvider.hasKey(redisKey)) { // 중복 체크 -> 하지 않으면 기존 코드가 사용 불가능하기 때문
+            redisProvider.set(redisKey, courseInviteReq, INVITE_EXPIRE_TIME);
         }
 
-        return CourseInviteRes.builder().url(DOMAIN + key).build();
+        return CourseInviteRes.builder()
+                .url(INVITE_DOMAIN + inviteUtil.encryptCourseInviteReq(courseInviteReq))
+                .build();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
+++ b/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
@@ -81,7 +81,11 @@ public class CourseService {
 
         // 링크 생성
         String redisKey = INVITE_PREFIX + courseInviteReq.getCourseId();
-        CourseInviteRedisReq courseInviteRedisReq = CourseInviteRedisReq.builder().userId(courseInviteReq.getUserId()).courseId(courseInviteReq.getCourseId()).build();
+        CourseInviteRedisReq courseInviteRedisReq =
+                CourseInviteRedisReq.builder()
+                        .userId(courseInviteReq.getUserId())
+                        .courseId(courseInviteReq.getCourseId())
+                        .build();
 
         if (!redisProvider.hasKey(redisKey)) { // 중복 체크 -> 하지 않으면 기존 코드가 사용 불가능하기 때문
             redisProvider.set(redisKey, courseInviteRedisReq, INVITE_EXPIRE_TIME);

--- a/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
+++ b/src/main/java/com/pcb/audy/domain/course/service/CourseService.java
@@ -81,7 +81,7 @@ public class CourseService {
 
         // 링크 생성
         String redisKey = INVITE_PREFIX + courseInviteReq.getCourseId();
-        CourseInviteRedisReq courseInviteRedisReq = CourseInviteRedisReq.builder().courseId(courseInviteReq.getCourseId()).build();
+        CourseInviteRedisReq courseInviteRedisReq = CourseInviteRedisReq.builder().userId(courseInviteReq.getUserId()).courseId(courseInviteReq.getCourseId()).build();
 
         if (!redisProvider.hasKey(redisKey)) { // 중복 체크 -> 하지 않으면 기존 코드가 사용 불가능하기 때문
             redisProvider.set(redisKey, courseInviteRedisReq, INVITE_EXPIRE_TIME);

--- a/src/main/java/com/pcb/audy/global/response/ResultCode.java
+++ b/src/main/java/com/pcb/audy/global/response/ResultCode.java
@@ -21,7 +21,10 @@ public enum ResultCode {
 
     NOT_FOUND_PIN(4000, "핀을 찾을 수 없습니다."),
 
-    NOT_FOUND_EDITOR(5000, "에디터를 찾을 수 없습니다.");
+    NOT_FOUND_EDITOR(5000, "에디터를 찾을 수 없습니다."),
+
+    FAILED_ENCRYPT(6000, "객체 암호화에 실패하였습니다."),
+    FAILED_DECRYPT(6001, "객체 복호화에 실패하였습니다.");
 
     private Integer code;
     private String message;

--- a/src/main/java/com/pcb/audy/global/util/InviteUtil.java
+++ b/src/main/java/com/pcb/audy/global/util/InviteUtil.java
@@ -1,6 +1,7 @@
 package com.pcb.audy.global.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pcb.audy.domain.course.dto.request.CourseInviteRedisReq;
 import com.pcb.audy.domain.course.dto.request.CourseInviteReq;
 import java.util.Base64;
 import javax.crypto.Cipher;
@@ -14,10 +15,10 @@ public class InviteUtil {
     @Value("${course-invite-key}")
     private String key;
 
-    public String encryptCourseInviteReq(CourseInviteReq courseInviteReq) throws Exception {
+    public String encryptCourseInviteReq(CourseInviteRedisReq courseInviteRedisReq) throws Exception {
         // 객체를 JSON 문자열로 변환
         ObjectMapper objectMapper = new ObjectMapper();
-        String json = objectMapper.writeValueAsString(courseInviteReq);
+        String json = objectMapper.writeValueAsString(courseInviteRedisReq);
 
         // AES 키 생성 및 암호화
         SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), "AES");
@@ -29,7 +30,7 @@ public class InviteUtil {
         return Base64.getEncoder().encodeToString(encryptedBytes);
     }
 
-    public CourseInviteReq decryptCourseInviteReq(String encryptedData) throws Exception {
+    public CourseInviteRedisReq decryptCourseInviteReq(String encryptedData) throws Exception {
         // Base64 인코딩된 문자열을 바이트 배열로 변환
         byte[] decodedBytes = Base64.getDecoder().decode(encryptedData);
 
@@ -44,6 +45,6 @@ public class InviteUtil {
 
         // JSON 문자열을 CourseInviteReq 객체로 변환
         ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.readValue(json, CourseInviteReq.class);
+        return objectMapper.readValue(json, CourseInviteRedisReq.class);
     }
 }

--- a/src/main/java/com/pcb/audy/global/util/InviteUtil.java
+++ b/src/main/java/com/pcb/audy/global/util/InviteUtil.java
@@ -1,0 +1,49 @@
+package com.pcb.audy.global.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pcb.audy.domain.course.dto.request.CourseInviteReq;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InviteUtil {
+
+    @Value("${course-invite-key}")
+    private String key;
+
+    public String encryptCourseInviteReq(CourseInviteReq courseInviteReq) throws Exception {
+        // 객체를 JSON 문자열로 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(courseInviteReq);
+
+        // AES 키 생성 및 암호화
+        SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), "AES");
+        Cipher cipher = Cipher.getInstance("AES");
+        cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
+        byte[] encryptedBytes = cipher.doFinal(json.getBytes());
+
+        // 암호화된 데이터를 Base64 문자열로 변환
+        return Base64.getEncoder().encodeToString(encryptedBytes);
+    }
+
+    public CourseInviteReq decryptCourseInviteReq(String encryptedData) throws Exception {
+        // Base64 인코딩된 문자열을 바이트 배열로 변환
+        byte[] decodedBytes = Base64.getDecoder().decode(encryptedData);
+
+        // AES 복호화
+        Cipher cipher = Cipher.getInstance("AES");
+        SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), "AES");
+        cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
+        byte[] decryptedBytes = cipher.doFinal(decodedBytes);
+
+        // 복호화된 데이터를 JSON 문자열로 변환
+        String json = new String(decryptedBytes);
+
+        // JSON 문자열을 CourseInviteReq 객체로 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(json, CourseInviteReq.class);
+    }
+}

--- a/src/main/java/com/pcb/audy/global/util/InviteUtil.java
+++ b/src/main/java/com/pcb/audy/global/util/InviteUtil.java
@@ -35,7 +35,6 @@ public class InviteUtil {
             // 암호화된 데이터를 Base64 문자열로 변환
             return Base64.getEncoder().encodeToString(encryptedBytes);
         } catch (Exception e) {
-            System.out.println(e.getMessage());
             throw new GlobalException(FAILED_ENCRYPT);
         }
     }
@@ -52,7 +51,7 @@ public class InviteUtil {
             byte[] decryptedBytes = cipher.doFinal(decodedBytes);
 
             // 복호화된 데이터를 JSON 문자열로 변환
-            String json = new String(decryptedBytes);
+            String json = decryptedBytes.toString();
 
             // JSON 문자열을 CourseInviteReq 객체로 변환
             return objectMapper.readValue(json, CourseInviteRedisReq.class);

--- a/src/main/java/com/pcb/audy/global/util/InviteUtil.java
+++ b/src/main/java/com/pcb/audy/global/util/InviteUtil.java
@@ -1,13 +1,24 @@
 package com.pcb.audy.global.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pcb.audy.domain.course.dto.request.CourseInviteRedisReq;
 import com.pcb.audy.domain.course.dto.request.CourseInviteReq;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
+
+import com.pcb.audy.global.exception.GlobalException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import static com.pcb.audy.global.response.ResultCode.*;
 
 @Component
 public class InviteUtil {
@@ -15,36 +26,45 @@ public class InviteUtil {
     @Value("${course-invite-key}")
     private String key;
 
-    public String encryptCourseInviteReq(CourseInviteRedisReq courseInviteRedisReq) throws Exception {
-        // 객체를 JSON 문자열로 변환
-        ObjectMapper objectMapper = new ObjectMapper();
-        String json = objectMapper.writeValueAsString(courseInviteRedisReq);
+    public String encryptCourseInviteReq(CourseInviteRedisReq courseInviteRedisReq) {
+        try{
+            // 객체를 JSON 문자열로 변환
+            ObjectMapper objectMapper = new ObjectMapper();
+            String json = objectMapper.writeValueAsString(courseInviteRedisReq);
 
-        // AES 키 생성 및 암호화
-        SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), "AES");
-        Cipher cipher = Cipher.getInstance("AES");
-        cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
-        byte[] encryptedBytes = cipher.doFinal(json.getBytes());
+            // AES 키 생성 및 암호화
+            SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), "AES");
+            Cipher cipher = Cipher.getInstance("AES");
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
+            byte[] encryptedBytes = cipher.doFinal(json.getBytes());
 
-        // 암호화된 데이터를 Base64 문자열로 변환
-        return Base64.getEncoder().encodeToString(encryptedBytes);
+            // 암호화된 데이터를 Base64 문자열로 변환
+            return Base64.getEncoder().encodeToString(encryptedBytes);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            throw new GlobalException(FAILED_ENCRYPT);
+        }
     }
 
-    public CourseInviteRedisReq decryptCourseInviteReq(String encryptedData) throws Exception {
-        // Base64 인코딩된 문자열을 바이트 배열로 변환
-        byte[] decodedBytes = Base64.getDecoder().decode(encryptedData);
+    public CourseInviteRedisReq decryptCourseInviteReq(String encryptedData) {
+        try{
+            // Base64 인코딩된 문자열을 바이트 배열로 변환
+            byte[] decodedBytes = Base64.getDecoder().decode(encryptedData);
 
-        // AES 복호화
-        Cipher cipher = Cipher.getInstance("AES");
-        SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), "AES");
-        cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
-        byte[] decryptedBytes = cipher.doFinal(decodedBytes);
+            // AES 복호화
+            Cipher cipher = Cipher.getInstance("AES");
+            SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), "AES");
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
+            byte[] decryptedBytes = cipher.doFinal(decodedBytes);
 
-        // 복호화된 데이터를 JSON 문자열로 변환
-        String json = new String(decryptedBytes);
+            // 복호화된 데이터를 JSON 문자열로 변환
+            String json = new String(decryptedBytes);
 
-        // JSON 문자열을 CourseInviteReq 객체로 변환
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.readValue(json, CourseInviteRedisReq.class);
+            // JSON 문자열을 CourseInviteReq 객체로 변환
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, CourseInviteRedisReq.class);
+        } catch (Exception e) {
+            throw new GlobalException(FAILED_DECRYPT);
+        }
     }
 }

--- a/src/main/java/com/pcb/audy/global/util/InviteUtil.java
+++ b/src/main/java/com/pcb/audy/global/util/InviteUtil.java
@@ -15,21 +15,25 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
 
 import com.pcb.audy.global.exception.GlobalException;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import static com.pcb.audy.global.response.ResultCode.*;
 
 @Component
+@RequiredArgsConstructor
 public class InviteUtil {
 
     @Value("${course-invite-key}")
     private String key;
 
+    private final ObjectMapper objectMapper;
+
     public String encryptCourseInviteReq(CourseInviteRedisReq courseInviteRedisReq) {
         try{
             // 객체를 JSON 문자열로 변환
-            ObjectMapper objectMapper = new ObjectMapper();
             String json = objectMapper.writeValueAsString(courseInviteRedisReq);
 
             // AES 키 생성 및 암호화
@@ -61,7 +65,6 @@ public class InviteUtil {
             String json = new String(decryptedBytes);
 
             // JSON 문자열을 CourseInviteReq 객체로 변환
-            ObjectMapper objectMapper = new ObjectMapper();
             return objectMapper.readValue(json, CourseInviteRedisReq.class);
         } catch (Exception e) {
             throw new GlobalException(FAILED_DECRYPT);

--- a/src/main/java/com/pcb/audy/global/util/InviteUtil.java
+++ b/src/main/java/com/pcb/audy/global/util/InviteUtil.java
@@ -1,26 +1,16 @@
 package com.pcb.audy.global.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import static com.pcb.audy.global.response.ResultCode.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pcb.audy.domain.course.dto.request.CourseInviteRedisReq;
-import com.pcb.audy.domain.course.dto.request.CourseInviteReq;
-
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.spec.SecretKeySpec;
-
 import com.pcb.audy.global.exception.GlobalException;
-import lombok.AllArgsConstructor;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import static com.pcb.audy.global.response.ResultCode.*;
 
 @Component
 @RequiredArgsConstructor
@@ -32,7 +22,7 @@ public class InviteUtil {
     private final ObjectMapper objectMapper;
 
     public String encryptCourseInviteReq(CourseInviteRedisReq courseInviteRedisReq) {
-        try{
+        try {
             // 객체를 JSON 문자열로 변환
             String json = objectMapper.writeValueAsString(courseInviteRedisReq);
 
@@ -51,7 +41,7 @@ public class InviteUtil {
     }
 
     public CourseInviteRedisReq decryptCourseInviteReq(String encryptedData) {
-        try{
+        try {
             // Base64 인코딩된 문자열을 바이트 배열로 변환
             byte[] decodedBytes = Base64.getDecoder().decode(encryptedData);
 

--- a/src/test/java/com/pcb/audy/domain/course/service/CourseServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/course/service/CourseServiceTest.java
@@ -26,6 +26,7 @@ import com.pcb.audy.domain.user.repository.UserRepository;
 import com.pcb.audy.global.exception.GlobalException;
 import com.pcb.audy.global.meta.Role;
 import com.pcb.audy.global.redis.RedisProvider;
+import com.pcb.audy.global.util.InviteUtil;
 import com.pcb.audy.test.PinTest;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +50,7 @@ class CourseServiceTest implements PinTest {
     @Mock private UserRepository userRepository;
     @Mock private EditorRepository editorRepository;
     @Mock private RedisProvider redisProvider;
+    @Mock private InviteUtil inviteUtil;
 
     @Nested
     class course_저장 {
@@ -293,13 +295,14 @@ class CourseServiceTest implements PinTest {
 
     @Test
     @DisplayName("초대 링크 생성")
-    void 초대_링크_생성() {
+    void 초대_링크_생성() throws Exception {
         // given
         CourseInviteReq courseInviteReq =
                 CourseInviteReq.builder().courseId(TEST_COURSE_ID).userId(TEST_USER_ID).build();
         when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
         when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
         when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(TEST_EDITOR_ADMIN);
+        when(redisProvider.hasKey(any())).thenReturn(false);
 
         // when
         CourseInviteRes courseInviteRes = courseService.inviteCourse(courseInviteReq);
@@ -307,6 +310,6 @@ class CourseServiceTest implements PinTest {
         // then
         verify(userRepository).findByUserId(any());
         verify(courseRepository).findByCourseId(any());
-        verify(redisProvider).get(any());
+        verify(redisProvider).set(any(), any(), anyLong());
     }
 }

--- a/src/test/java/com/pcb/audy/domain/course/service/CourseServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/course/service/CourseServiceTest.java
@@ -293,23 +293,50 @@ class CourseServiceTest implements PinTest {
         verify(courseRepository).findByCourseId(any());
     }
 
-    @Test
-    @DisplayName("초대 링크 생성")
-    void 초대_링크_생성() throws Exception {
-        // given
-        CourseInviteReq courseInviteReq =
-                CourseInviteReq.builder().courseId(TEST_COURSE_ID).userId(TEST_USER_ID).build();
-        when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
-        when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
-        when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(TEST_EDITOR_ADMIN);
-        when(redisProvider.hasKey(any())).thenReturn(false);
+    @Nested
+    class course_초대_링크_생성 {
+        @Test
+        @DisplayName("초대 링크 생성")
+        void 초대_링크_최초_생성() throws Exception {
+            // given
+            CourseInviteReq courseInviteReq =
+                    CourseInviteReq.builder().courseId(TEST_COURSE_ID).userId(TEST_USER_ID).build();
+            when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
+            when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
+            when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(TEST_EDITOR_ADMIN);
+            when(redisProvider.hasKey(any())).thenReturn(false);
 
-        // when
-        CourseInviteRes courseInviteRes = courseService.inviteCourse(courseInviteReq);
+            // when
+            CourseInviteRes courseInviteRes = courseService.inviteCourse(courseInviteReq);
 
-        // then
-        verify(userRepository).findByUserId(any());
-        verify(courseRepository).findByCourseId(any());
-        verify(redisProvider).set(any(), any(), anyLong());
+            // then
+            verify(userRepository).findByUserId(any());
+            verify(courseRepository).findByCourseId(any());
+            verify(editorRepository).findByUserAndCourse(any(), any());
+            verify(redisProvider).hasKey(any());
+            verify(redisProvider).set(any(), any(), anyLong());
+        }
+
+        @Test
+        @DisplayName("초대 링크 중복 생성")
+        void 초대_링크_중복_생성() throws Exception {
+            // given
+            CourseInviteReq courseInviteReq =
+                    CourseInviteReq.builder().courseId(TEST_COURSE_ID).userId(TEST_USER_ID).build();
+            when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
+            when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
+            when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(TEST_EDITOR_ADMIN);
+            when(redisProvider.hasKey(any())).thenReturn(true);
+
+            // when
+            CourseInviteRes courseInviteRes = courseService.inviteCourse(courseInviteReq);
+
+            // then
+            verify(userRepository).findByUserId(any());
+            verify(courseRepository).findByCourseId(any());
+            verify(editorRepository).findByUserAndCourse(any(), any());
+            verify(redisProvider).hasKey(any());
+            verify(redisProvider, never()).set(any(), any(), anyLong());
+        }
     }
 }


### PR DESCRIPTION
## 개요
코스 초대 API 변경

## 작업사항
- 코스 초대 API에서 InviteReq를 암호화해서 쓰도록, redis에는 원본객체를 쓰도록 변경
- InviteUtil 생성
- 코스 초대 api 수정

## 관련 이슈
- close #87 