### PR TITLE
코스 단건 조회 로직 수정

### DIFF
--- a/src/main/java/com/pcb/audy/domain/course/dto/response/CourseDetailGetRes.java
+++ b/src/main/java/com/pcb/audy/domain/course/dto/response/CourseDetailGetRes.java
@@ -11,12 +11,12 @@ public class CourseDetailGetRes {
 
     private Long courseId;
     private String courseName;
-    private List<PinGetRes> pinList;
+    private List<PinGetRes> pinResList;
 
     @Builder
-    private CourseDetailGetRes(Long courseId, String courseName, List<PinGetRes> pinList) {
+    private CourseDetailGetRes(Long courseId, String courseName, List<PinGetRes> pinResList) {
         this.courseId = courseId;
         this.courseName = courseName;
-        this.pinList = pinList;
+        this.pinResList = pinResList;
     }
 }

--- a/src/main/java/com/pcb/audy/domain/course/service/CourseServiceMapper.java
+++ b/src/main/java/com/pcb/audy/domain/course/service/CourseServiceMapper.java
@@ -6,6 +6,7 @@ import com.pcb.audy.domain.course.dto.response.CourseSaveRes;
 import com.pcb.audy.domain.course.entity.Course;
 import com.pcb.audy.domain.editor.entity.Editor;
 import com.pcb.audy.domain.pin.dto.response.PinGetRes;
+import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
 import com.pcb.audy.domain.pin.entity.Pin;
 import java.util.List;
 import org.mapstruct.Mapper;
@@ -35,8 +36,14 @@ public interface CourseServiceMapper {
 
     List<CourseGetRes> toCourseGetResList(List<Editor> editor);
 
-    PinGetRes toPinGetRes(Pin pin);
+    PinGetRes redisToPinGetRes(PinSaveRes pin);
 
-    @Mapping(target = "pinList", source = "pinList")
-    CourseDetailGetRes toCourseDetailGetRes(Course course);
+    List<PinSaveRes> toPinGetRes(List<Pin> pin);
+
+    @Mapping(target = "courseId", expression = "java(pin.getCourse().getCourseId())")
+    PinSaveRes toPinSaveRes(Pin pin);
+
+    List<PinSaveRes> toPinSaveResList(List<Pin> pinList);
+
+    CourseDetailGetRes toCourseDetailGetRes(Course course, List<PinSaveRes> pinResList);
 }

--- a/src/test/java/com/pcb/audy/domain/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/course/controller/CourseControllerTest.java
@@ -110,7 +110,7 @@ class CourseControllerTest extends BaseMvcTest implements CourseTest {
                 CourseDetailGetRes.builder()
                         .courseId(TEST_COURSE_ID)
                         .courseName(TEST_COURSE_NAME)
-                        .pinList(List.of(pinGetRes))
+                        .pinResList(List.of(pinGetRes))
                         .build();
 
         when(courseService.getCourse(any())).thenReturn(courseDetailGetRes);

--- a/src/test/java/com/pcb/audy/domain/course/service/CourseServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/course/service/CourseServiceTest.java
@@ -18,7 +18,6 @@ import com.pcb.audy.domain.course.dto.request.CourseUpdateReq;
 import com.pcb.audy.domain.course.dto.response.CourseDetailGetRes;
 import com.pcb.audy.domain.course.dto.response.CourseGetResList;
 import com.pcb.audy.domain.course.dto.response.CourseInviteRes;
-import com.pcb.audy.domain.course.dto.response.CourseSaveRes;
 import com.pcb.audy.domain.course.entity.Course;
 import com.pcb.audy.domain.course.repository.CourseRepository;
 import com.pcb.audy.domain.editor.entity.Editor;
@@ -31,8 +30,6 @@ import com.pcb.audy.global.meta.Role;
 import com.pcb.audy.global.redis.RedisProvider;
 import com.pcb.audy.global.util.InviteUtil;
 import com.pcb.audy.test.PinTest;
-
-import java.lang.runtime.ObjectMethods;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -288,7 +285,6 @@ class CourseServiceTest implements PinTest {
         assertEquals(1, courseGetResList.getCourseGetResList().size());
     }
 
-
     @Nested
     class course_상세_조회 {
 
@@ -305,7 +301,7 @@ class CourseServiceTest implements PinTest {
             // then
             verify(courseRepository).findByCourseId(any());
             verify(redisProvider).getByPattern(any());
-            verify(redisProvider, never()).multiSet(any());
+            verify(redisProvider).multiSet(any());
         }
 
         @Test
@@ -325,7 +321,6 @@ class CourseServiceTest implements PinTest {
             verify(redisProvider).getByPattern(any());
             verify(redisProvider, never()).multiSet(any());
         }
-
     }
 
     @Nested

--- a/src/test/java/com/pcb/audy/test/PinTest.java
+++ b/src/test/java/com/pcb/audy/test/PinTest.java
@@ -1,5 +1,6 @@
 package com.pcb.audy.test;
 
+import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
 import com.pcb.audy.domain.pin.entity.Pin;
 import java.util.UUID;
 
@@ -24,5 +25,17 @@ public interface PinTest extends CourseTest {
                     .address(TEST_ADDRESS)
                     .sequence(TEST_SEQUENCE)
                     .course(TEST_COURSE)
+                    .build();
+
+    PinSaveRes TEST_PIN_SAVED =
+            PinSaveRes.builder()
+                    .pinId(TEST_PIN_ID)
+                    .pinName(TEST_PIN_NAME)
+                    .originName(TEST_ORIGIN_NAME)
+                    .latitude(TEST_LATITUDE)
+                    .longitude(TEST_LONGITUDE)
+                    .address(TEST_ADDRESS)
+                    .sequence(TEST_SEQUENCE)
+                    .courseId(TEST_COURSE_ID)
                     .build();
 }


### PR DESCRIPTION
## 개요
코스 단건 조회 로직 수정

## 작업사항
- Redis에서 핀을 먼저 가져오기 → 없다면 데이터베이스 핀 조회하는 방식으로 로직 수정
- Redis에 핀이 없다면 조회와 동시에 Redis에 모든 핀 업로드 하도록 수정
- 모든 핀 업로드 시 Redis Pipeline 적용
- pinList -> pinResList 변수명 수정 (Mapper 사용시에 course의 pinList가 자동으로 mapping되어 redis 보다 먼저 db에 있는 값이 추가가 되어버려 변수명 변경했습니다)

## 관련 이슈
- close #67 
