### PR TITLE
핀 삭제 api 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -39,6 +39,11 @@ include::{snippets}/../../src/docs/custom-snippets/socket/pin/pin-save-response.
 include::{snippets}/../../src/docs/custom-snippets/socket/pin/pin-name-update-request.adoc[]
 include::{snippets}/../../src/docs/custom-snippets/socket/pin/pin-name-update-response.adoc[]
 
+=== Delete Pin
+
+include::{snippets}/../../src/docs/custom-snippets/socket/pin/pin-delete-request.adoc[]
+include::{snippets}/../../src/docs/custom-snippets/socket/pin/pin-delete-response.adoc[]
+
 == course API
 
 include::{snippets}/course-controller-test/course_저장/auto-section.adoc[]

--- a/src/docs/custom-snippets/socket/pin/pin-delete-request.adoc
+++ b/src/docs/custom-snippets/socket/pin/pin-delete-request.adoc
@@ -1,0 +1,9 @@
+[source,http,options="nowrap"]
+----
+SEND /pub/{courseId}/pin/removal
+EX /pub/1/pin/removal
+Content-Type: application/json
+{
+    "pinId": "10b24e0e-7d7f-49ab-858d-14097f47ee8a"
+}
+----

--- a/src/docs/custom-snippets/socket/pin/pin-delete-response.adoc
+++ b/src/docs/custom-snippets/socket/pin/pin-delete-response.adoc
@@ -1,0 +1,13 @@
+[source,http,options="nowrap"]
+----
+SUBSCRIBE /sub/{courseId}/pin/removal
+EX /sub/1/pin/removal
+Content-Type: application/json
+{
+  "code" : 0,
+  "message" : "실행에 성공했습니다.",
+  "data" : {
+    "pinId" : "10b24e0e-7d7f-49ab-858d-14097f47ee8a"
+  }
+}
+----

--- a/src/main/java/com/pcb/audy/domain/pin/controller/PinController.java
+++ b/src/main/java/com/pcb/audy/domain/pin/controller/PinController.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,8 +34,10 @@ public class PinController {
         return BasicResponse.success(pinService.updatePinName(courseId, pinNameUpdateReq));
     }
 
-    @DeleteMapping
-    public BasicResponse<PinDeleteRes> deletePin(@RequestBody PinDeleteReq pinDeleteReq) {
-        return BasicResponse.success(pinService.deletePin(pinDeleteReq));
+    @MessageMapping("/{courseId}/pin/removal")
+    @SendTo("/sub/{courseId}/pin/removal")
+    public BasicResponse<PinDeleteRes> deletePin(
+            @DestinationVariable Long courseId, @RequestBody PinDeleteReq pinDeleteReq) {
+        return BasicResponse.success(pinService.deletePin(courseId, pinDeleteReq));
     }
 }

--- a/src/main/java/com/pcb/audy/domain/pin/dto/request/PinDeleteReq.java
+++ b/src/main/java/com/pcb/audy/domain/pin/dto/request/PinDeleteReq.java
@@ -9,12 +9,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PinDeleteReq {
-    private Long courseId;
     private UUID pinId;
 
     @Builder
-    private PinDeleteReq(Long courseId, UUID pinId) {
-        this.courseId = courseId;
+    private PinDeleteReq(UUID pinId) {
         this.pinId = pinId;
     }
 }

--- a/src/main/java/com/pcb/audy/domain/pin/dto/response/PinDeleteRes.java
+++ b/src/main/java/com/pcb/audy/domain/pin/dto/response/PinDeleteRes.java
@@ -1,6 +1,18 @@
 package com.pcb.audy.domain.pin.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@JsonIgnoreProperties
-public class PinDeleteRes {}
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PinDeleteRes {
+    private UUID pinId;
+
+    @Builder
+    private PinDeleteRes(UUID pinId) {
+        this.pinId = pinId;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
+++ b/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
@@ -49,12 +49,12 @@ public class PinService {
         return PinServiceMapper.INSTANCE.toPinNameUpdateRes(updatedPin);
     }
 
-    public PinDeleteRes deletePin(PinDeleteReq pinDeleteReq) {
-        //        String key = getKey(pinDeleteReq.getCourseId(), pinDeleteReq.getPinId());
-        //        Pin pin = (Pin) redisProvider.get(key);
-        //                PinValidator.validate(pin);
-        //        redisProvider.delete(key);
-        return new PinDeleteRes();
+    public PinDeleteRes deletePin(Long courseId, PinDeleteReq pinDeleteReq) {
+        String key = getKey(courseId, pinDeleteReq.getPinId());
+        PinRedisRes pinRedisRes = objectMapper.convertValue(redisProvider.get(key), PinRedisRes.class);
+        PinValidator.validate(pinRedisRes);
+        redisProvider.delete(key);
+        return PinServiceMapper.INSTANCE.toPinDeleteRes(pinRedisRes);
     }
 
     private String getKey(Long courseId, UUID pinId) {

--- a/src/main/java/com/pcb/audy/domain/pin/service/PinServiceMapper.java
+++ b/src/main/java/com/pcb/audy/domain/pin/service/PinServiceMapper.java
@@ -1,6 +1,7 @@
 package com.pcb.audy.domain.pin.service;
 
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
+import com.pcb.audy.domain.pin.dto.response.PinDeleteRes;
 import com.pcb.audy.domain.pin.dto.response.PinNameUpdateRes;
 import com.pcb.audy.domain.pin.dto.response.PinRedisRes;
 import com.pcb.audy.domain.pin.dto.response.PinSaveRes;
@@ -18,4 +19,6 @@ public interface PinServiceMapper {
     PinSaveRes toPinSaveRes(PinRedisRes pinRedisRes);
 
     PinNameUpdateRes toPinNameUpdateRes(PinRedisRes pinRedisRes);
+
+    PinDeleteRes toPinDeleteRes(PinRedisRes pinRedisRes);
 }


### PR DESCRIPTION
## 개요
pin 삭제 api를 web socket 방식으로 수정합니다.

## 작업사항
- MessageMapping으로 수정
- restdocs 수정

## 관련 이슈
- close #86 
