### PR TITLE
editor 권한 변경 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -54,3 +54,7 @@ include::{snippets}/course-controller-test/course_상세_조회/auto-section.ado
 include::{snippets}/course-controller-test/course_전체_조회/auto-section.adoc[]
 include::{snippets}/course-controller-test/관리자_course_전체_조회/auto-section.adoc[]
 include::{snippets}/course-controller-test/멤버_course_전체_조회/auto-section.adoc[]
+
+== editor API
+
+include::{snippets}/editor-controller-test/editor_역할_수정/auto-section.adoc[]

--- a/src/main/java/com/pcb/audy/domain/editor/controller/EditorController.java
+++ b/src/main/java/com/pcb/audy/domain/editor/controller/EditorController.java
@@ -1,0 +1,28 @@
+package com.pcb.audy.domain.editor.controller;
+
+import com.pcb.audy.domain.editor.dto.request.EditorRoleUpdateReq;
+import com.pcb.audy.domain.editor.dto.response.EditorRoleUpdateRes;
+import com.pcb.audy.domain.editor.service.EditorService;
+import com.pcb.audy.global.auth.PrincipalDetails;
+import com.pcb.audy.global.response.BasicResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/editors")
+@RequiredArgsConstructor
+public class EditorController {
+    private final EditorService editorService;
+
+    @PatchMapping
+    public BasicResponse<EditorRoleUpdateRes> updateEditorRole(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody EditorRoleUpdateReq editorRoleUpdateReq) {
+        editorRoleUpdateReq.setUserId(principalDetails.getUser().getUserId());
+        return BasicResponse.success(editorService.updateRoleEditor(editorRoleUpdateReq));
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/editor/dto/request/EditorRoleUpdateReq.java
+++ b/src/main/java/com/pcb/audy/domain/editor/dto/request/EditorRoleUpdateReq.java
@@ -1,0 +1,26 @@
+package com.pcb.audy.domain.editor.dto.request;
+
+import com.pcb.audy.global.meta.Role;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EditorRoleUpdateReq {
+    private Long userId;
+    private Long courseId;
+    private Long selectedUserId;
+    private Role role;
+
+    @Builder
+    private EditorRoleUpdateReq(Long userId, Long courseId, Long selectedUserId, Role role) {
+        this.userId = userId;
+        this.courseId = courseId;
+        this.selectedUserId = selectedUserId;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/editor/dto/response/EditorRoleUpdateRes.java
+++ b/src/main/java/com/pcb/audy/domain/editor/dto/response/EditorRoleUpdateRes.java
@@ -1,0 +1,6 @@
+package com.pcb.audy.domain.editor.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class EditorRoleUpdateRes {}

--- a/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
+++ b/src/main/java/com/pcb/audy/domain/editor/service/EditorService.java
@@ -1,0 +1,59 @@
+package com.pcb.audy.domain.editor.service;
+
+import com.pcb.audy.domain.course.entity.Course;
+import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.editor.dto.request.EditorRoleUpdateReq;
+import com.pcb.audy.domain.editor.dto.response.EditorRoleUpdateRes;
+import com.pcb.audy.domain.editor.entity.Editor;
+import com.pcb.audy.domain.editor.repository.EditorRepository;
+import com.pcb.audy.domain.user.entity.User;
+import com.pcb.audy.domain.user.repository.UserRepository;
+import com.pcb.audy.global.validator.CourseValidator;
+import com.pcb.audy.global.validator.EditorValidator;
+import com.pcb.audy.global.validator.UserValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EditorService {
+    private final EditorRepository editorRepository;
+    private final UserRepository userRepository;
+    private final CourseRepository courseRepository;
+
+    @Transactional
+    public EditorRoleUpdateRes updateRoleEditor(EditorRoleUpdateReq editorRoleUpdateReq) {
+        User user = getUserByUserId(editorRoleUpdateReq.getUserId());
+        Course course = getCourseByCourseId(editorRoleUpdateReq.getCourseId());
+        Editor editor = getEditor(user, course);
+        EditorValidator.checkIsAdminUser(editor);
+
+        User selectedUser = getUserByUserId(editorRoleUpdateReq.getSelectedUserId());
+        editorRepository.save(
+                Editor.builder()
+                        .user(selectedUser)
+                        .course(course)
+                        .role(editorRoleUpdateReq.getRole())
+                        .build());
+        return new EditorRoleUpdateRes();
+    }
+
+    private User getUserByUserId(Long userId) {
+        User user = userRepository.findByUserId(userId);
+        UserValidator.validate(user);
+        return user;
+    }
+
+    private Course getCourseByCourseId(Long courseId) {
+        Course course = courseRepository.findByCourseId(courseId);
+        CourseValidator.validate(course);
+        return course;
+    }
+
+    private Editor getEditor(User user, Course course) {
+        Editor editor = editorRepository.findByUserAndCourse(user, course);
+        EditorValidator.validate(editor);
+        return editor;
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/editor/controller/EditorControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/editor/controller/EditorControllerTest.java
@@ -1,0 +1,45 @@
+package com.pcb.audy.domain.editor.controller;
+
+import static com.pcb.audy.global.meta.Role.MEMBER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.pcb.audy.domain.BaseMvcTest;
+import com.pcb.audy.domain.editor.dto.request.EditorRoleUpdateReq;
+import com.pcb.audy.domain.editor.dto.response.EditorRoleUpdateRes;
+import com.pcb.audy.domain.editor.service.EditorService;
+import com.pcb.audy.test.EditorTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(controllers = {EditorController.class})
+class EditorControllerTest extends BaseMvcTest implements EditorTest {
+    @MockBean private EditorService editorService;
+
+    @Test
+    @DisplayName("editor 역할 수정 테스트")
+    void editor_역할_수정() throws Exception {
+        EditorRoleUpdateReq editorRoleUpdateReq =
+                EditorRoleUpdateReq.builder()
+                        .courseId(TEST_COURSE_ID)
+                        .selectedUserId(TEST_ANOTHER_USER_ID)
+                        .role(MEMBER)
+                        .build();
+        EditorRoleUpdateRes editorRoleUpdateRes = new EditorRoleUpdateRes();
+        when(editorService.updateRoleEditor(any())).thenReturn(editorRoleUpdateRes);
+        this.mockMvc
+                .perform(
+                        patch("/v1/editors")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(editorRoleUpdateReq))
+                                .principal(this.mockPrincipal))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/editor/service/EditorServiceTest.java
@@ -1,0 +1,88 @@
+package com.pcb.audy.domain.editor.service;
+
+import static com.pcb.audy.global.meta.Role.MEMBER;
+import static com.pcb.audy.global.response.ResultCode.NOT_ADMIN_COURSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pcb.audy.domain.course.repository.CourseRepository;
+import com.pcb.audy.domain.editor.dto.request.EditorRoleUpdateReq;
+import com.pcb.audy.domain.editor.repository.EditorRepository;
+import com.pcb.audy.domain.user.repository.UserRepository;
+import com.pcb.audy.global.exception.GlobalException;
+import com.pcb.audy.test.EditorTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EditorServiceTest implements EditorTest {
+    @InjectMocks private EditorService editorService;
+    @Mock private EditorRepository editorRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private CourseRepository courseRepository;
+
+    @Nested
+    class editor_역할_수정 {
+        @Test
+        @DisplayName("editor 역할 수정 테스트")
+        void editor_역할_수정() {
+            // given
+            EditorRoleUpdateReq editorRoleUpdateReq =
+                    EditorRoleUpdateReq.builder()
+                            .courseId(TEST_COURSE_ID)
+                            .selectedUserId(TEST_ANOTHER_USER_ID)
+                            .role(MEMBER)
+                            .build();
+            when(userRepository.findByUserId(any())).thenReturn(TEST_USER).thenReturn(TEST_ANOTHER_USER);
+            when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
+            when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(TEST_EDITOR_ADMIN);
+
+            // when
+            editorService.updateRoleEditor(editorRoleUpdateReq);
+
+            // then
+            verify(userRepository, times(2)).findByUserId(any());
+            verify(courseRepository).findByCourseId(any());
+            verify(editorRepository).findByUserAndCourse(any(), any());
+            verify(editorRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("editor 역할 수정 실패 테스트")
+        void editor_역할_수정_실패() {
+            // given
+            EditorRoleUpdateReq editorRoleUpdateReq =
+                    EditorRoleUpdateReq.builder()
+                            .courseId(TEST_COURSE_ID)
+                            .selectedUserId(TEST_ANOTHER_USER_ID)
+                            .role(MEMBER)
+                            .build();
+            when(userRepository.findByUserId(any())).thenReturn(TEST_USER);
+            when(courseRepository.findByCourseId(any())).thenReturn(TEST_COURSE);
+            when(editorRepository.findByUserAndCourse(any(), any())).thenReturn(TEST_EDITOR_MEMBER);
+
+            // when
+            GlobalException exception =
+                    assertThrows(
+                            GlobalException.class,
+                            () -> {
+                                editorService.updateRoleEditor(editorRoleUpdateReq);
+                            });
+
+            // then
+            verify(userRepository).findByUserId(any());
+            verify(courseRepository).findByCourseId(any());
+            verify(editorRepository).findByUserAndCourse(any(), any());
+            assertThat(exception.getResultCode()).isEqualTo(NOT_ADMIN_COURSE);
+        }
+    }
+}

--- a/src/test/java/com/pcb/audy/test/EditorTest.java
+++ b/src/test/java/com/pcb/audy/test/EditorTest.java
@@ -1,11 +1,9 @@
 package com.pcb.audy.test;
 
-import static com.pcb.audy.test.UserTest.TEST_USER;
-
 import com.pcb.audy.domain.editor.entity.Editor;
 import com.pcb.audy.global.meta.Role;
 
-public interface EditorTest extends CourseTest {
+public interface EditorTest extends CourseTest, UserTest {
 
     Editor TEST_EDITOR_ADMIN =
             Editor.builder().course(TEST_COURSE).user(TEST_USER).role(Role.OWNER).build();

--- a/src/test/java/com/pcb/audy/test/UserTest.java
+++ b/src/test/java/com/pcb/audy/test/UserTest.java
@@ -13,9 +13,22 @@ public interface UserTest {
     String TEST_USER_EMAIL = "username@gmail.com";
     String TEST_USER_IMAGE_URL = "imageUrl";
 
+    Long TEST_ANOTHER_USER_ID = 2L;
+
     User TEST_USER =
             User.builder()
                     .userId(TEST_USER_ID)
+                    .oauthId(TEST_OAUTH_ID)
+                    .email(TEST_USER_EMAIL)
+                    .username(TEST_USER_NAME)
+                    .authority(USER)
+                    .social(KAKAO)
+                    .imageUrl(TEST_USER_IMAGE_URL)
+                    .build();
+
+    User TEST_ANOTHER_USER =
+            User.builder()
+                    .userId(TEST_ANOTHER_USER_ID)
                     .oauthId(TEST_OAUTH_ID)
                     .email(TEST_USER_EMAIL)
                     .username(TEST_USER_NAME)


### PR DESCRIPTION
## 개요
editor 권한 변경 api를 추가합니다.

## 작업사항
- editor 권한 변경 api 추가
- 테스트코드 추가
- restdocs에 api 추가

## 관련 이슈
- close #73 
