### PR TITLE
서버 시간 설정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM openjdk:17-jdk
 COPY ./build/libs/audy-0.0.1-SNAPSHOT.jar app.jar
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app.jar"]

--- a/src/main/java/com/pcb/audy/global/jwt/JwtUtils.java
+++ b/src/main/java/com/pcb/audy/global/jwt/JwtUtils.java
@@ -13,7 +13,6 @@ import java.security.Key;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/pcb/audy/global/jwt/JwtUtils.java
+++ b/src/main/java/com/pcb/audy/global/jwt/JwtUtils.java
@@ -10,6 +10,10 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletResponse;
 import java.security.Key;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +50,7 @@ public class JwtUtils {
                 Jwts.builder()
                         .setSubject("accessToken")
                         .claim("email", email)
-                        .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
+                        .setExpiration(new Date(getCurrentTimestamp() + ACCESS_TOKEN_EXPIRE_TIME))
                         .signWith(key, SignatureAlgorithm.HS256)
                         .compact();
 
@@ -58,7 +62,7 @@ public class JwtUtils {
                 Jwts.builder()
                         .setSubject("refreshToken")
                         .claim("email", email)
-                        .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME))
+                        .setExpiration(new Date(getCurrentTimestamp() + REFRESH_TOKEN_EXPIRE_TIME))
                         .signWith(key, SignatureAlgorithm.HS256)
                         .compact();
 
@@ -110,5 +114,10 @@ public class JwtUtils {
                         .build();
 
         response.addHeader("Set-Cookie", responseCookie.toString());
+    }
+
+    private long getCurrentTimestamp() {
+        Timestamp timestamp = Timestamp.valueOf(LocalDateTime.now());
+        return timestamp.toInstant().atZone(ZoneId.of("Asia/Seoul")).toEpochSecond();
     }
 }


### PR DESCRIPTION
## 개요
server 시간을 리턴하도록 수정합니다.

## 작업사항
- Dockerfile로 실행 시 시간을 `Asia/Seoul`로 설정
- token 발급 시 서버 시간을 리턴하도록 수정

## 관련 이슈
- close #106 
