### PR TITLE
초대 링크 UrlEncoding 추가

### DIFF
--- a/src/main/java/com/pcb/audy/global/util/InviteUtil.java
+++ b/src/main/java/com/pcb/audy/global/util/InviteUtil.java
@@ -5,6 +5,8 @@ import static com.pcb.audy.global.response.ResultCode.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pcb.audy.domain.course.dto.request.CourseInviteRedisReq;
 import com.pcb.audy.global.exception.GlobalException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Base64;
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
@@ -32,8 +34,11 @@ public class InviteUtil {
             cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
             byte[] encryptedBytes = cipher.doFinal(json.getBytes());
 
-            // 암호화된 데이터를 Base64 문자열로 변환
-            return Base64.getEncoder().encodeToString(encryptedBytes);
+            // 암호화된 데이터를 Base64 문자열로 변환 (필요한 경우)
+            String base64Encoded = Base64.getEncoder().encodeToString(encryptedBytes);
+
+            // Base64 인코딩 문자열을 URL 인코딩
+            return URLEncoder.encode(base64Encoded, "UTF-8");
         } catch (Exception e) {
             throw new GlobalException(FAILED_ENCRYPT);
         }
@@ -41,8 +46,10 @@ public class InviteUtil {
 
     public CourseInviteRedisReq decryptCourseInviteReq(String encryptedData) {
         try {
+            String decodedData = URLDecoder.decode(encryptedData, "UTF-8");
+
             // Base64 인코딩된 문자열을 바이트 배열로 변환
-            byte[] decodedBytes = Base64.getDecoder().decode(encryptedData);
+            byte[] decodedBytes = Base64.getDecoder().decode(decodedData);
 
             // AES 복호화
             Cipher cipher = Cipher.getInstance("AES");


### PR DESCRIPTION
## 개요
기존의 코드로는 url의 암호화 부분에 /가 포함되어 api 요청이 제대로 안 되었기 때문에,
프론트의 요청으로 초대링크에 Url Encoding을 추가했습니다.

## 작업사항
- 초대링크에 Url Encoding 추가

## 관련 이슈
- close #125
