### PR TITLE
소켓 동시 접속 유저 조회 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -26,6 +26,7 @@ include::{snippets}/sample-controller-test/샘플_전체_조회/auto-section.ado
 == user API
 
 include::{snippets}/user-controller-test/유저_조회/auto-section.adoc[]
+include::{snippets}/user-controller-test/코스_동시_접속_유저_조회/auto-section.adoc[]
 
 == pin API
 

--- a/src/main/java/com/pcb/audy/domain/user/controller/UserController.java
+++ b/src/main/java/com/pcb/audy/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.pcb.audy.domain.user.controller;
 
 import com.pcb.audy.domain.user.dto.response.UserGetRes;
+import com.pcb.audy.domain.user.dto.response.UserGetResList;
 import com.pcb.audy.domain.user.service.UserService;
 import com.pcb.audy.global.auth.PrincipalDetails;
 import com.pcb.audy.global.response.BasicResponse;
@@ -26,5 +27,10 @@ public class UserController {
         }
 
         return BasicResponse.success(userService.getUser(userId));
+    }
+
+    @GetMapping("/course")
+    public BasicResponse<UserGetResList> getCourseUser(@RequestParam Long courseId) {
+        return BasicResponse.success(userService.getUsers(courseId));
     }
 }

--- a/src/main/java/com/pcb/audy/domain/user/dto/response/SocketUserGetRes.java
+++ b/src/main/java/com/pcb/audy/domain/user/dto/response/SocketUserGetRes.java
@@ -1,0 +1,17 @@
+package com.pcb.audy.domain.user.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocketUserGetRes {
+    private Long userId;
+
+    @Builder
+    private SocketUserGetRes(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/user/dto/response/UserGetResList.java
+++ b/src/main/java/com/pcb/audy/domain/user/dto/response/UserGetResList.java
@@ -1,0 +1,20 @@
+package com.pcb.audy.domain.user.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserGetResList {
+    private List<UserGetRes> users;
+    private int total;
+
+    @Builder
+    private UserGetResList(List<UserGetRes> users, int total) {
+        this.users = users;
+        this.total = total;
+    }
+}

--- a/src/main/java/com/pcb/audy/domain/user/dto/response/UserGetResList.java
+++ b/src/main/java/com/pcb/audy/domain/user/dto/response/UserGetResList.java
@@ -9,11 +9,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserGetResList {
-    private List<UserGetRes> users;
+    private List<SocketUserGetRes> users;
     private int total;
 
     @Builder
-    private UserGetResList(List<UserGetRes> users, int total) {
+    private UserGetResList(List<SocketUserGetRes> users, int total) {
         this.users = users;
         this.total = total;
     }

--- a/src/main/java/com/pcb/audy/domain/user/service/UserService.java
+++ b/src/main/java/com/pcb/audy/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.pcb.audy.domain.user.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pcb.audy.domain.user.dto.response.SocketUserGetRes;
 import com.pcb.audy.domain.user.dto.response.UserGetRes;
 import com.pcb.audy.domain.user.dto.response.UserGetResList;
 import com.pcb.audy.domain.user.entity.User;
@@ -29,7 +30,7 @@ public class UserService {
     public UserGetResList getUsers(Long courseId) {
         String key = COURSE_PREFIX + courseId;
 
-        List<UserGetRes> users =
+        List<SocketUserGetRes> users =
                 UserServiceMapper.INSTANCE.toUserGetResList(
                         redisProvider.getValues(key).stream()
                                 .map(user -> objectMapper.convertValue(user, User.class))

--- a/src/main/java/com/pcb/audy/domain/user/service/UserService.java
+++ b/src/main/java/com/pcb/audy/domain/user/service/UserService.java
@@ -1,20 +1,40 @@
 package com.pcb.audy.domain.user.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pcb.audy.domain.user.dto.response.UserGetRes;
+import com.pcb.audy.domain.user.dto.response.UserGetResList;
 import com.pcb.audy.domain.user.entity.User;
 import com.pcb.audy.domain.user.repository.UserRepository;
+import com.pcb.audy.global.redis.RedisProvider;
 import com.pcb.audy.global.validator.UserValidator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
+    private final RedisProvider redisProvider;
     private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    private final String COURSE_PREFIX = "socket:";
 
     public UserGetRes getUser(Long userId) {
         User user = userRepository.findByUserId(userId);
         UserValidator.validate(user);
         return UserServiceMapper.INSTANCE.toUserGetRes(user);
+    }
+
+    public UserGetResList getUsers(Long courseId) {
+        String key = COURSE_PREFIX + courseId;
+
+        List<UserGetRes> users =
+                UserServiceMapper.INSTANCE.toUserGetResList(
+                        redisProvider.getValues(key).stream()
+                                .map(user -> objectMapper.convertValue(user, User.class))
+                                .toList());
+
+        return UserGetResList.builder().users(users).total(users.size()).build();
     }
 }

--- a/src/main/java/com/pcb/audy/domain/user/service/UserServiceMapper.java
+++ b/src/main/java/com/pcb/audy/domain/user/service/UserServiceMapper.java
@@ -2,6 +2,7 @@ package com.pcb.audy.domain.user.service;
 
 import com.pcb.audy.domain.user.dto.response.UserGetRes;
 import com.pcb.audy.domain.user.entity.User;
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
@@ -10,4 +11,6 @@ public interface UserServiceMapper {
     UserServiceMapper INSTANCE = Mappers.getMapper(UserServiceMapper.class);
 
     UserGetRes toUserGetRes(User user);
+
+    List<UserGetRes> toUserGetResList(List<User> users);
 }

--- a/src/main/java/com/pcb/audy/domain/user/service/UserServiceMapper.java
+++ b/src/main/java/com/pcb/audy/domain/user/service/UserServiceMapper.java
@@ -1,5 +1,6 @@
 package com.pcb.audy.domain.user.service;
 
+import com.pcb.audy.domain.user.dto.response.SocketUserGetRes;
 import com.pcb.audy.domain.user.dto.response.UserGetRes;
 import com.pcb.audy.domain.user.entity.User;
 import java.util.List;
@@ -12,5 +13,5 @@ public interface UserServiceMapper {
 
     UserGetRes toUserGetRes(User user);
 
-    List<UserGetRes> toUserGetResList(List<User> users);
+    List<SocketUserGetRes> toUserGetResList(List<User> users);
 }

--- a/src/main/java/com/pcb/audy/global/redis/RedisProvider.java
+++ b/src/main/java/com/pcb/audy/global/redis/RedisProvider.java
@@ -25,6 +25,15 @@ public class RedisProvider {
         return redisTemplate.opsForValue().get(key);
     }
 
+    public List<Object> getValues(String key) {
+        Long len = redisTemplate.opsForList().size(key);
+        if (len == 0) {
+            return List.of();
+        }
+
+        return redisTemplate.opsForList().range(key, 0, len - 1);
+    }
+
     public List<Object> getByPattern(String pattern) {
         Set<String> keys = redisTemplate.keys(pattern);
         if (CollectionUtils.isEmpty(keys)) {

--- a/src/main/java/com/pcb/audy/global/redis/RedisProvider.java
+++ b/src/main/java/com/pcb/audy/global/redis/RedisProvider.java
@@ -79,7 +79,7 @@ public class RedisProvider {
 
     public void setValues(String key, Object o, long expireTime) {
         Long len = redisTemplate.opsForList().size(key);
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(o.getClass()));
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
         redisTemplate.opsForList().remove(key, 1L, o);
         redisTemplate.opsForList().rightPush(key, o);
 

--- a/src/main/java/com/pcb/audy/global/socket/handler/CustomChannelInterceptor.java
+++ b/src/main/java/com/pcb/audy/global/socket/handler/CustomChannelInterceptor.java
@@ -19,7 +19,6 @@ public class CustomChannelInterceptor implements ChannelInterceptor {
     private final RedisProvider redisProvider;
     private final ObjectMapper objectMapper;
     private final String SOCKET_PREFIX = "socket:";
-    private final String SEPAR = ":";
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -30,8 +29,7 @@ public class CustomChannelInterceptor implements ChannelInterceptor {
             SocketPrincipal socketPrincipal =
                     objectMapper.convertValue(accessor.getUser(), SocketPrincipal.class);
             String courseId = objectMapper.convertValue(keys.get("courseId"), String.class);
-            redisProvider.setValues(
-                    getKey(courseId, accessor.getSessionId()), socketPrincipal.getUser(), Integer.MAX_VALUE);
+            redisProvider.setValues(getKey(courseId), socketPrincipal.getUser(), Integer.MAX_VALUE);
         }
 
         return message;
@@ -40,7 +38,7 @@ public class CustomChannelInterceptor implements ChannelInterceptor {
     @Override
     public void postSend(Message<?> message, MessageChannel channel, boolean sent) {}
 
-    private String getKey(String courseId, String session) {
-        return SOCKET_PREFIX + courseId + SEPAR + session;
+    private String getKey(String courseId) {
+        return SOCKET_PREFIX + courseId;
     }
 }

--- a/src/test/java/com/pcb/audy/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/user/controller/UserControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.pcb.audy.domain.BaseMvcTest;
+import com.pcb.audy.domain.user.dto.response.SocketUserGetRes;
 import com.pcb.audy.domain.user.dto.response.UserGetRes;
 import com.pcb.audy.domain.user.dto.response.UserGetResList;
 import com.pcb.audy.domain.user.service.UserService;
@@ -44,15 +45,9 @@ class UserControllerTest extends BaseMvcTest implements UserTest, CourseTest {
     @DisplayName("코스 동시 접속 유저 조회 테스트")
     void 코스_동시_접속_유저_조회() throws Exception {
         Long courseId = TEST_COURSE_ID;
-        UserGetRes userGetRes =
-                UserGetRes.builder()
-                        .userId(TEST_USER_ID)
-                        .email(TEST_USER_EMAIL)
-                        .username(TEST_USER_NAME)
-                        .imageUrl(TEST_USER_IMAGE_URL)
-                        .build();
+        SocketUserGetRes socketUserGetRes = SocketUserGetRes.builder().userId(TEST_USER_ID).build();
         UserGetResList userGetResList =
-                UserGetResList.builder().users(List.of(userGetRes)).total(1).build();
+                UserGetResList.builder().users(List.of(socketUserGetRes)).total(1).build();
         when(userService.getUsers(any())).thenReturn(userGetResList);
         this.mockMvc
                 .perform(get("/v1/users/course").param("courseId", String.valueOf(courseId)))

--- a/src/test/java/com/pcb/audy/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/pcb/audy/domain/user/controller/UserControllerTest.java
@@ -8,15 +8,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.pcb.audy.domain.BaseMvcTest;
 import com.pcb.audy.domain.user.dto.response.UserGetRes;
+import com.pcb.audy.domain.user.dto.response.UserGetResList;
 import com.pcb.audy.domain.user.service.UserService;
+import com.pcb.audy.test.CourseTest;
 import com.pcb.audy.test.UserTest;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @WebMvcTest(controllers = {UserController.class})
-class UserControllerTest extends BaseMvcTest implements UserTest {
+class UserControllerTest extends BaseMvcTest implements UserTest, CourseTest {
     @MockBean private UserService userService;
 
     @Test
@@ -33,6 +36,26 @@ class UserControllerTest extends BaseMvcTest implements UserTest {
         when(userService.getUser(any())).thenReturn(userGetRes);
         this.mockMvc
                 .perform(get("/v1/users").param("userId", String.valueOf(userId)))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("코스 동시 접속 유저 조회 테스트")
+    void 코스_동시_접속_유저_조회() throws Exception {
+        Long courseId = TEST_COURSE_ID;
+        UserGetRes userGetRes =
+                UserGetRes.builder()
+                        .userId(TEST_USER_ID)
+                        .email(TEST_USER_EMAIL)
+                        .username(TEST_USER_NAME)
+                        .imageUrl(TEST_USER_IMAGE_URL)
+                        .build();
+        UserGetResList userGetResList =
+                UserGetResList.builder().users(List.of(userGetRes)).total(1).build();
+        when(userService.getUsers(any())).thenReturn(userGetResList);
+        this.mockMvc
+                .perform(get("/v1/users/course").param("courseId", String.valueOf(courseId)))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/pcb/audy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/user/service/UserServiceTest.java
@@ -5,9 +5,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pcb.audy.domain.user.dto.response.UserGetRes;
+import com.pcb.audy.domain.user.dto.response.UserGetResList;
 import com.pcb.audy.domain.user.repository.UserRepository;
+import com.pcb.audy.global.redis.RedisProvider;
+import com.pcb.audy.test.CourseTest;
 import com.pcb.audy.test.UserTest;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,10 +21,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class UserServiceTest implements UserTest {
+class UserServiceTest implements UserTest, CourseTest {
     @InjectMocks private UserService userService;
 
     @Mock private UserRepository userRepository;
+    @Mock private RedisProvider redisProvider;
+    @Mock private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("유저 조회 테스트")
@@ -36,5 +43,21 @@ class UserServiceTest implements UserTest {
         assertThat(userGetRes.getEmail()).isEqualTo(TEST_USER_EMAIL);
         assertThat(userGetRes.getUsername()).isEqualTo(TEST_USER_NAME);
         assertThat(userGetRes.getImageUrl()).isEqualTo(TEST_USER_IMAGE_URL);
+    }
+
+    @Test
+    @DisplayName("동시 접속 유저 조회 테스트")
+    void 동시_접속_유저_조회() {
+        // given
+        Long courseId = TEST_COURSE_ID;
+        List<Object> users = List.of(TEST_USER, TEST_ANOTHER_USER);
+        when(redisProvider.getValues(any())).thenReturn(users);
+
+        // when
+        UserGetResList userGetResList = userService.getUsers(courseId);
+
+        // then
+        assertThat(userGetResList.getTotal()).isEqualTo(2);
+        verify(redisProvider).getValues(any());
     }
 }

--- a/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
+++ b/src/test/java/com/pcb/audy/global/redis/RedisProviderTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.pcb.audy.test.RedisTest;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +63,25 @@ class RedisProviderTest implements RedisTest {
     }
 
     @Test
+    @DisplayName("데이터 list 조회 테스트")
+    void 데이터_list_조회() {
+        // given
+        when(redisTemplate.opsForList()).thenReturn(listOperations);
+        when(listOperations.size(any())).thenReturn(1L);
+        when(listOperations.range(any(), anyLong(), anyLong())).thenReturn(List.of(TEST_VALUE));
+
+        // when
+        List<Object> values = redisProvider.getValues(TEST_KEY);
+
+        // then
+        verify(redisTemplate, times(2)).opsForList();
+        verify(listOperations).size(any());
+        verify(listOperations).range(any(), anyLong(), anyLong());
+        assertThat(values.size()).isEqualTo(1);
+        assertThat(values.get(0)).isEqualTo(TEST_VALUE);
+    }
+
+    @Test
     @DisplayName("데이터 삭제 테스트")
     void 데이터_삭제() {
         // given
@@ -87,7 +107,6 @@ class RedisProviderTest implements RedisTest {
         assertThat(result).isEqualTo(TRUE);
     }
 
-    // TODO add save list
     @Test
     @DisplayName("데이터 list에 저장 테스트")
     void 데이터_list_저장() {


### PR DESCRIPTION
## 개요
소켓 동시 접속 유저 조회 api 추가

## 작업사항
- 소켓 동시 접속 유저 조회 api 추가
- 테스트코드 추가
- restdocs 추가

## 관련 이슈
- #108 
