### PR TITLE
Pin 전용 redisTemplate 분리

### DIFF
--- a/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
+++ b/src/main/java/com/pcb/audy/domain/pin/service/PinService.java
@@ -34,7 +34,7 @@ public class PinService {
         String sequence = lexoRankUtil.getLexoRank(courseId, size);
         PinRedisRes pinRedisRes =
                 PinServiceMapper.INSTANCE.toPinRedisRes(pinSaveReq, courseId, sequence);
-        redisProvider.set(getKey(courseId, pinRedisRes.getPinId()), pinRedisRes, PIN_EXPIRE_TIME);
+        redisProvider.setPin(getKey(courseId, pinRedisRes.getPinId()), pinRedisRes, PIN_EXPIRE_TIME);
         return PinServiceMapper.INSTANCE.toPinSaveRes(pinRedisRes);
     }
 
@@ -55,7 +55,7 @@ public class PinService {
                         .sequence(sequence)
                         .build();
 
-        redisProvider.set(key, updatedPinRedisRes, PIN_EXPIRE_TIME);
+        redisProvider.setPin(key, updatedPinRedisRes, PIN_EXPIRE_TIME);
         return PinServiceMapper.INSTANCE.toPinOrderUpdateRes(pinOrderUpdateReq);
     }
 
@@ -75,7 +75,7 @@ public class PinService {
                         .address(prevPin.getAddress())
                         .sequence(prevPin.getSequence())
                         .build();
-        redisProvider.set(key, updatedPin, PIN_EXPIRE_TIME);
+        redisProvider.setPin(key, updatedPin, PIN_EXPIRE_TIME);
         return PinServiceMapper.INSTANCE.toPinNameUpdateRes(updatedPin);
     }
 

--- a/src/main/java/com/pcb/audy/domain/pin/service/PinServiceMapper.java
+++ b/src/main/java/com/pcb/audy/domain/pin/service/PinServiceMapper.java
@@ -3,6 +3,7 @@ package com.pcb.audy.domain.pin.service;
 import com.pcb.audy.domain.pin.dto.request.PinOrderUpdateReq;
 import com.pcb.audy.domain.pin.dto.request.PinSaveReq;
 import com.pcb.audy.domain.pin.dto.response.*;
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -17,6 +18,10 @@ public interface PinServiceMapper {
     PinRedisRes toPinRedisRes(PinSaveReq pinSaveReq, Long courseId, String sequence);
 
     PinSaveRes toPinSaveRes(PinRedisRes pinRedisRes);
+
+    PinGetRes toPinGetRes(PinRedisRes pinRedisRes);
+
+    List<PinGetRes> toPinGetResList(List<PinRedisRes> pinList);
 
     PinNameUpdateRes toPinNameUpdateRes(PinRedisRes pinRedisRes);
 

--- a/src/main/java/com/pcb/audy/global/redis/RedisConfig.java
+++ b/src/main/java/com/pcb/audy/global/redis/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.pcb.audy.global.redis;
 
+import com.pcb.audy.domain.pin.dto.response.PinRedisRes;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,5 +30,15 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, PinRedisRes> pinRedisTemplate(
+            RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, PinRedisRes> pinRedisTemplate = new RedisTemplate<>();
+        pinRedisTemplate.setConnectionFactory(connectionFactory);
+        pinRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        pinRedisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(PinRedisRes.class));
+        return pinRedisTemplate;
     }
 }

--- a/src/main/java/com/pcb/audy/global/util/LexoRankUtil.java
+++ b/src/main/java/com/pcb/audy/global/util/LexoRankUtil.java
@@ -1,10 +1,10 @@
 package com.pcb.audy.global.util;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.pravin.raha.lexorank4j.LexoRank;
 import com.pcb.audy.domain.pin.dto.response.PinGetRes;
+import com.pcb.audy.domain.pin.dto.response.PinRedisRes;
+import com.pcb.audy.domain.pin.service.PinServiceMapper;
 import com.pcb.audy.global.redis.RedisProvider;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +18,6 @@ import org.springframework.util.CollectionUtils;
 public class LexoRankUtil {
 
     private final RedisProvider redisProvider;
-    private final ObjectMapper objectMapper;
 
     public String getLexoRank(Long courseId, int order) {
         // 어떤 코스에(courseId), 몇 번째 순서에(order), 어떤 핀을 넣을 것인가(target)
@@ -43,19 +42,12 @@ public class LexoRankUtil {
 
     public List<PinGetRes> sortByLexoRank(Long courseId) {
         String pattern = courseId + ":*";
-        List<Object> redisData = redisProvider.getByPattern(pattern);
+        List<PinRedisRes> redisData = redisProvider.getPinsByPattern(pattern);
 
         if (redisData == null) {
             return List.of();
         }
-
-        List<PinGetRes> pinResList = new ArrayList<>();
-        for (Object pin : redisData) {
-            PinGetRes pinRedisRes = objectMapper.convertValue(pin, PinGetRes.class);
-            pinResList.add(pinRedisRes);
-        }
-
-        Collections.sort(pinResList);
-        return pinResList;
+        Collections.sort(redisData);
+        return PinServiceMapper.INSTANCE.toPinGetResList(redisData);
     }
 }

--- a/src/test/java/com/pcb/audy/domain/pin/service/PinServiceTest.java
+++ b/src/test/java/com/pcb/audy/domain/pin/service/PinServiceTest.java
@@ -79,7 +79,7 @@ class PinServiceTest implements PinTest {
         // then
         verify(redisProvider).get(any());
         verify(objectMapper).convertValue(any(), eq(PinRedisRes.class));
-        verify(redisProvider).set(any(), any(), anyLong());
+        verify(redisProvider).setPin(any(), any(), anyLong());
         assertThat(pinNameUpdateRes.getPinName()).isEqualTo(TEST_UPDATED_PIN_NAME);
     }
 


### PR DESCRIPTION
## 개요
Pin 전용 redisTemplate 분리

## 작업사항
- Pin 전용 redisTemplate를 분리하여, get 로직의 Default 값을 pinGetRes로 변환 해 값을 가져오도록 수정했습니다

## 관련 이슈
- close #135 
